### PR TITLE
Updated required version for cache-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
-        "sonata-project/cache-bundle": "master-dev"
+        "sonata-project/cache-bundle": "2.0.*"
     },
     "autoload": {
         "psr-0": { "Sonata\\BlockBundle": "" }


### PR DESCRIPTION
Updated required version for sonata-project/cache-bundle (from master-dev to 2.0.*).
