### PR TITLE
Add name property to block model

### DIFF
--- a/Model/BaseBlock.php
+++ b/Model/BaseBlock.php
@@ -10,26 +10,64 @@
 
 namespace Sonata\BlockBundle\Model;
 
+/**
+ * Base abstract Block class that provides a default implementation of the block interface
+ */
 abstract class BaseBlock implements BlockInterface
 {
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var array
+     */
     protected $settings;
 
+    /**
+     * @var boolean
+     */
     protected $enabled;
 
+    /**
+     * @var integer
+     */
     protected $position;
 
+    /**
+     * @var BlockInterface
+     */
     protected $parent;
 
+    /**
+     * @var array
+     */
     protected $children;
 
+    /**
+     * @var \DateTime
+     */
     protected $createdAt;
 
+    /**
+     * @var \DateTime
+     */
     protected $updatedAt;
 
+    /**
+     * @var string
+     */
     protected $type;
 
+    /**
+     * @var integer
+     */
     protected $ttl;
 
+    /**
+     * Constructor
+     */
     public function __construct()
     {
         $this->settings = array();
@@ -37,7 +75,23 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public function setType($type)
     {
@@ -45,7 +99,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getType()
     {
@@ -53,7 +107,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setSettings(array $settings = array())
     {
@@ -61,7 +115,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getSettings()
     {
@@ -69,7 +123,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setSetting($name, $value)
     {
@@ -77,7 +131,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getSetting($name, $default = null)
     {
@@ -85,7 +139,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setEnabled($enabled)
     {
@@ -93,7 +147,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getEnabled()
     {
@@ -101,7 +155,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setPosition($position)
     {
@@ -109,7 +163,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getPosition()
     {
@@ -117,7 +171,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setCreatedAt(\DateTime $createdAt = null)
     {
@@ -125,7 +179,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getCreatedAt()
     {
@@ -133,7 +187,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setUpdatedAt(\DateTime $updatedAt = null)
     {
@@ -141,7 +195,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getUpdatedAt()
     {
@@ -149,7 +203,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function addChildren(BlockInterface $child)
     {
@@ -159,7 +213,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getChildren()
     {
@@ -167,7 +221,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setParent(BlockInterface $parent = null)
     {
@@ -175,7 +229,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getParent()
     {
@@ -183,7 +237,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function hasParent()
     {
@@ -191,15 +245,15 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function __toString()
     {
-        return 'block (id:'.$this->getId().')';
+        return sprintf('block %d : "%s"', $this->getId(), $this->getname());
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getTtl()
     {
@@ -219,7 +273,7 @@ abstract class BaseBlock implements BlockInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function hasChildren()
     {

--- a/Model/Block.php
+++ b/Model/Block.php
@@ -10,12 +10,18 @@
 
 namespace Sonata\BlockBundle\Model;
 
+/**
+ * Block model with concrete implementation of BlockInterface
+ */
 class Block extends BaseBlock
 {
+    /**
+     * @var mixed
+     */
     protected $id;
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function setId($id)
     {
@@ -23,7 +29,7 @@ class Block extends BaseBlock
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function getId()
     {

--- a/Model/BlockInterface.php
+++ b/Model/BlockInterface.php
@@ -11,162 +11,196 @@
 
 namespace Sonata\BlockBundle\Model;
 
+/**
+ * Interface of Block
+ */
 interface BlockInterface
 {
     /**
+     * Sets the block Id
+     *
      * @param mixed $id
+     *
      * @return void
      */
     function setId($id);
 
     /**
+     * Returns the block id
+     *
      * @return mixed void
      */
     function getId();
 
     /**
-     * Set type
+     * Sets the name
+     *
+     * @param string $name
+     */
+    function setName($name);
+
+    /**
+     * Returns the name
+     *
+     * @return string
+     */
+    function getName();
+
+    /**
+     * Sets the type
      *
      * @param string $type
      */
     function setType($type);
 
     /**
-     * Get type
+     * Returns the type
      *
      * @return string $type
      */
     function getType();
 
     /**
-     * Set enabled
+     * Sets whether or not this block is enabled
      *
      * @param boolean $enabled
      */
     function setEnabled($enabled);
 
     /**
-     * Get enabled
+     * Returns whether or not this block is enabled
      *
      * @return boolean $enabled
      */
     function getEnabled();
 
     /**
-     * Set position
+     * Set the block ordered position
      *
      * @param integer $position
      */
     function setPosition($position);
 
     /**
-     * Get position
+     * Returns the block ordered position
      *
      * @return integer $position
      */
     function getPosition();
 
     /**
-     * Set createdAt
+     * Sets the creation date and time
      *
      * @param \Datetime $createdAt
      */
     function setCreatedAt(\DateTime $createdAt = null);
 
     /**
-     * Get createdAt
+     * Returns the creation date and time
      *
      * @return \Datetime $createdAt
      */
     function getCreatedAt();
 
     /**
-     * Set updatedAt
+     * Set the last update date and time
      *
      * @param \Datetime $updatedAt
      */
     function setUpdatedAt(\DateTime $updatedAt = null);
 
     /**
-     * Get updatedAt
+     * Returns the last update date and time
      *
      * @return \Datetime $updatedAt
      */
     function getUpdatedAt();
 
     /**
-     * Add children
+     * Add one child block
      *
      * @param BlockInterface $children
      */
     function addChildren(BlockInterface $children);
 
     /**
-     * Get children
+     * Returns child blocks
      *
      * @return \Doctrine\Common\Collections\Collection $children
      */
     function getChildren();
 
     /**
-     * @return bool
+     * Returns whether or not this block has children
+     *
+     * @return boolean
      */
     function hasChildren();
 
     /**
-     * Set parent
+     * Set the parent block
      *
-     * @param BlockInterface $parent
+     * @param BlockInterface|null $parent
      */
-    function setParent(BlockInterface $parent);
+    function setParent(BlockInterface $parent = null);
 
     /**
-     * Get parent
+     * Returns the parent block
      *
      * @return BlockInterface $parent
      */
     function getParent();
 
     /**
+     * Returns whether or not this block has a parent
+     *
      * @return void
      */
     function hasParent();
 
     /**
+     * Returns the block cache TTL
+     *
      * @return integer
      */
     function getTtl();
 
     /**
+     * Returns a string representation of the block
+     *
      * @return string
      */
     function __toString();
 
     /**
-     * Set settings
+     * Sets the block settings
      *
-     * @param array $settings
+     * @param array $settings An array of key/value
      */
     function setSettings(array $settings = array());
 
     /**
-     * Get settings
+     * Returns the block settings
      *
-     * @return array $settings
+     * @return array $settings An array of key/value
      */
     function getSettings();
 
     /**
-     * @param $name
-     * @param $value
-     * @return void
+     * Sets one block setting
+     *
+     * @param string $name  Key name
+     * @param mixed  $value Value
      */
     function setSetting($name, $value);
 
     /**
-     * @param $name
-     * @param null $default
-     * @return null
+     * Returns one block setting or the given default value if no value is found
+     *
+     * @param string     $name    Key name
+     * @param mixed|null $default Default value
+     *
+     * @return mixed
      */
     function getSetting($name, $default = null);
 }

--- a/Tests/Model/BlockTest.php
+++ b/Tests/Model/BlockTest.php
@@ -14,7 +14,6 @@ use Sonata\BlockBundle\Model\Block;
 
 class BlockTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testGetTtl()
     {
         $block = new Block;
@@ -46,6 +45,7 @@ class BlockTest extends \PHPUnit_Framework_TestCase
 
         $block = new Block;
 
+        $block->setName('my.block.name');
         $block->setCreatedAt($time);
         $block->setUpdatedAt($time);
         $block->setEnabled(true);
@@ -53,6 +53,7 @@ class BlockTest extends \PHPUnit_Framework_TestCase
         $block->setType('foo.bar');
         $block->setParent($parent);
 
+        $this->assertEquals('my.block.name', $block->getName());
         $this->assertEquals($time, $block->getCreatedAt());
         $this->assertEquals($time, $block->getUpdatedAt());
         $this->assertTrue($block->getEnabled());


### PR DESCRIPTION
Added a name property in the Block model class and interface (with get/set). 
Updated the __toString() to add the name in the string representation.
Cleaned up some code style in the concerned classes.
