### PR TITLE
Bug when using BlockService without children

### DIFF
--- a/Model/BaseBlock.php
+++ b/Model/BaseBlock.php
@@ -34,6 +34,7 @@ abstract class BaseBlock implements BlockInterface
     {
         $this->settings = array();
         $this->enabled  = false;
+        $this->children = array();
     }
 
     /**


### PR DESCRIPTION
If a BlockService is used without a Block instance (see example) an error will occur because BaseBlock::$children is not initialized.

``` twig
{{ sonata_block_render({'type':'...'}) }}
```

ErrorException: Warning: Invalid argument supplied for foreach() in ... vendor/sonata-project/block-bundle/Sonata/BlockBundle/Model/BaseBlock.php line 263

This bug will be fixed by initalizing BaseBlock::$children with an empty array.
