### PR TITLE
A Fix on Composer Dependency issue to SonataCache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
-        "sonata-project/cache-bundle": "2.0.*"
+        "sonata-project/cache-bundle": "master-dev"
     },
     "autoload": {
         "psr-0": { "Sonata\\BlockBundle": "" }


### PR DESCRIPTION
Changed dependency version from 2.0.\* to master-dev which currently works.
