### PR TITLE
Updated required version for cache-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
-        "sonata-project/cache-bundle": "2.0.*"
+        "sonata-project/cache-bundle": "2.0.x-dev"
     },
     "autoload": {
         "psr-0": { "Sonata\\BlockBundle": "" }


### PR DESCRIPTION
Updated to dev version of CacheBundle since composer changes the [default stability](https://groups.google.com/forum/#!topic/composer-dev/_g3ASeIFlrc/discussion) from dev to stable at 1.0.0-alpha4 (2012-07-04).
