### PR TITLE
Add block profiling in web debug toolbar

### DIFF
--- a/Block/TraceableBlockRenderer.php
+++ b/Block/TraceableBlockRenderer.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Block;
+
+use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Renders a block using a block service and traces the block rendering
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class TraceableBlockRenderer extends BlockRenderer
+{
+    /**
+     * @var array
+     */
+    protected $traces = array();
+
+    /**
+     * Renders a block and analyze metrics before and after the rendering
+     *
+     * @param BlockInterface $block    Block instance
+     * @param Response       $response Response object
+     *
+     * @return Response
+     */
+    public function render(BlockInterface $block, Response $response = null)
+    {
+        if ($this->debug) {
+            $this->startTracing($block);
+        }
+
+        $response = parent::render($block, $response);
+
+        if ($this->debug) {
+            $this->endTracing($block);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Start tracing the block rendering
+     *
+     * @param BlockInterface $block
+     */
+    public function startTracing(BlockInterface $block)
+    {
+        $this->traces[$block->getId()] = array(
+            'name'          => $block->getName(),
+            'type'          => $block->getType(),
+            'time_start'    => microtime(true),
+            'memory_start'  => memory_get_usage(true),
+        );
+    }
+
+    /**
+     * End tracing the block rendering
+     *
+     * @param BlockInterface $block
+     */
+    public function endTracing(BlockInterface $block)
+    {
+        $trace =& $this->traces[$block->getId()];
+
+        $trace = array_merge($trace, array(
+            'time_end'      => microtime(true),
+            'memory_end'    => memory_get_usage(true),
+            'memory_peak'   => memory_get_peak_usage(true),
+        ));
+    }
+
+    /**
+     * Returns the rendering traces
+     *
+     * @return array
+     */
+    public function getTraces()
+    {
+        return $this->traces;
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,6 +29,15 @@ class Configuration implements ConfigurationInterface
         $node = $treeBuilder->root('sonata_block')->children();
 
         $node
+            ->arrayNode('profiler')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('enabled')->defaultValue('%kernel.debug%')->end()
+                    ->scalarNode('renderer_class')->defaultValue('Sonata\BlockBundle\Block\TraceableBlockRenderer')->end()
+                    ->scalarNode('template')->defaultValue('SonataBlockBundle:Profiler:block.html.twig')->end()
+                ->end()
+            ->end()
+
             ->arrayNode('default_contexts')
                 ->isRequired()
                 ->prototype('scalar')->end()

--- a/DependencyInjection/SonataBlockExtension.php
+++ b/DependencyInjection/SonataBlockExtension.php
@@ -47,6 +47,7 @@ class SonataBlockExtension extends Extension
         $this->configureLoaderChain($container, $config);
         $this->configureCache($container, $config);
         $this->configureForm($container, $config);
+        $this->configureProfiler($container, $config);
 
         $bundles = $container->getParameter('kernel.bundles');
         if ($config['templates']['block_base'] === null) {
@@ -121,5 +122,28 @@ class SonataBlockExtension extends Extension
 
         $container->getDefinition('sonata.block.form.type.block')
             ->replaceArgument(1, $contexts);
+    }
+
+    /**
+     * Configures the block profiler
+     *
+     * @param ContainerBuilder $container Container
+     * @param array            $config    Configuration
+     */
+    public function configureProfiler(ContainerBuilder $container, array $config)
+    {
+        if (!$config['profiler']['enabled']) {
+            return;
+        }
+
+        // replace renderer with a traceable renderer
+        $renderer = $container->getDefinition('sonata.block.renderer');
+        $renderer->setClass($config['profiler']['renderer_class']);
+
+        // add the block data collector
+        $definition = new Definition('Sonata\BlockBundle\Profiler\DataCollector\BlockDataCollector');
+        $definition->addTag('data_collector', array('id' => 'block', 'template' => $config['profiler']['template']));
+        $definition->addArgument(new Reference('sonata.block.renderer'));
+        $container->addDefinitions(array($definition));
     }
 }

--- a/Profiler/DataCollector/BlockDataCollector.php
+++ b/Profiler/DataCollector/BlockDataCollector.php
@@ -1,0 +1,145 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Sonata\BlockBundle\Profiler\DataCollector;
+
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+use Sonata\BlockBundle\Block\TraceableBlockRenderer;
+
+/**
+ * Block data collector for the symfony web profiling
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class BlockDataCollector implements DataCollectorInterface, \Serializable
+{
+    /**
+     * @var TraceableBlockRenderer
+     */
+    protected $renderer;
+
+    /**
+     * @var array
+     */
+    protected $blocks = array();
+
+    /**
+     * @var array
+     */
+    protected $containers = array();
+
+    /**
+     * @var array
+     */
+    protected $realBlocks = array();
+
+    /**
+     * Constructor
+     *
+     * @param TraceableBlockRenderer $renderer Block renderer
+     */
+    public function __construct(TraceableBlockRenderer $renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
+    /**
+     * Collects the traces from the block renderer
+     *
+     * @param Request    $request   Http Request
+     * @param Response   $response  Http Response
+     * @param \Exception $exception Exception thrown
+     */
+    public function collect(Request $request, Response $response, \Exception $exception = null)
+    {
+        $this->blocks = $this->renderer->getTraces();
+
+        // split into containers & real blocks
+        foreach ($this->blocks as $block) {
+            if ($block['type'] === 'sonata.page.block.container') {
+                $this->containers[] = $block;
+            } else {
+                $this->realBlocks[] = $block;
+            }
+        }
+    }
+
+    /**
+     * Returns the block rendering history
+     *
+     * @return array
+     */
+    public function getBlocks()
+    {
+        return $this->blocks;
+    }
+
+    /**
+     * Returns the container blocks
+     *
+     * @return array
+     */
+    public function getContainers()
+    {
+        return $this->containers;
+    }
+
+    /**
+     * Returns the real blocks (non-container)
+     *
+     * @return array
+     */
+    public function getRealBlocks()
+    {
+        return $this->realBlocks;
+    }
+
+    /**
+     * serialize the data
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        $data = array(
+            'blocks'     => $this->blocks,
+            'containers' => $this->containers,
+            'realBlocks' => $this->realBlocks,
+        );
+
+        return serialize($data);
+    }
+
+    /**
+     * Unserialize the data
+     *
+     * @param string $data
+     *
+     * @return void
+     */
+    public function unserialize($data)
+    {
+        $merged = unserialize($data);
+
+        $this->blocks     = $merged['blocks'];
+        $this->containers = $merged['containers'];
+        $this->realBlocks = $merged['realBlocks'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'block';
+    }
+}

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -11,3 +11,4 @@ Reference Guide
    reference/installation
    reference/twig_helpers
    reference/your_first_block
+   reference/profiler

--- a/Resources/doc/reference/profiler.rst
+++ b/Resources/doc/reference/profiler.rst
@@ -1,0 +1,18 @@
+Profiler
+========
+
+``BlockBundle`` automatically adds the profiling of blocks in debug mode. It adds a new tab in the symfony web debug
+toolbar which contains the number of blocks used on a page. It also provides a panel with the list of all rendered
+blocks, their memory consumption and their rendering time.
+
+If you want to disable the profiling or configure it, you may add one of the following options in the block
+configuration file:
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    sonata_block:
+        profiler:
+            enabled:        %kernel.debug%
+            renderer_class: Sonata\BlockBundle\Block\TraceableBlockRenderer
+            template:       SonataBlockBundle:Profiler:block.html.twig

--- a/Resources/views/Profiler/block.html.twig
+++ b/Resources/views/Profiler/block.html.twig
@@ -1,0 +1,70 @@
+{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+
+{% block toolbar %}
+    <div class="sf-toolbar-block">
+        <div class="sf-toolbar-icon">
+            <a href="{{ path('_profiler', { 'token': token, 'panel': name }) }}">
+                {# fake image span #}<span style="width:0px; height: 28px; vertical-align: middle;"></span>
+                <span class="sf-toolbar-status">{{ collector.blocks|length }}</span> blocks
+            </a>
+        </div>
+        <div class="sf-toolbar-info">
+            <div class="sf-toolbar-info-piece">
+                <b>Real Blocks</b>
+                <span>{{ collector.realBlocks|length }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Containers</b>
+                <span>{{ collector.containers|length }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Total Blocks</b>
+                <span>{{ collector.blocks|length }}</span>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block menu %}
+    <span class="label">
+        <strong>Blocks</strong>
+        <span class="count">
+            <span>{{ collector.blocks|length }}</span>
+        </span>
+    </span>
+{% endblock %}
+
+{% block panel %}
+    <h2>Real Blocks</h2>
+    {% set blocks = collector.realBlocks %}
+    {{ block('table') }}
+
+    <h2>Containers Blocks</h2>
+    {% set blocks = collector.containers %}
+    {{ block('table') }}
+
+    {{ block('javascript') }}
+{% endblock %}
+
+{% block table %}
+    <table>
+        <tr>
+            <th>Id</th>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Memory (diff)</th>
+            <th>Memory (peak)</th>
+            <th>Duration</th>
+        </tr>
+        {% for id, block in blocks %}
+            <tr>
+                <th>{{ id }}</th>
+                <td>{{ block.name }}</td>
+                <td>{{ block.type }}</td>
+                <td>{{ ((block.memory_end-block.memory_start)/1000)|number_format(0) }} Kb</td>
+                <td>{{ (block.memory_peak/1000)|number_format(0) }} Kb</td>
+                <td>{{ ((block.time_end-block.time_start)*1000)|number_format(2) }} ms</td>
+            </tr>
+        {% endfor %}
+    </table>
+{% endblock %}


### PR DESCRIPTION
Adds block profiling in the symfony web debug toolbar:
- Only enabled in debug mode
- Shows the number of blocks rendered in the page.
- Shows the list of blocks with memory and time information.
- No configuration change is required.
