### PR TITLE
Feature: exception strategy management (updated)

### DIFF
--- a/Block/BlockRenderer.php
+++ b/Block/BlockRenderer.php
@@ -15,10 +15,25 @@ use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
+use Sonata\BlockBundle\Exception\Strategy\StrategyManagerInterface;
+
+/**
+ * Handles the execution and rendering of a block
+ */
 class BlockRenderer implements BlockRendererInterface
 {
     /**
-     * @var LoggerInterface
+     * @var BlockServiceManagerInterface
+     */
+    protected $blockServiceManager;
+
+    /**
+     * @var StrategyManagerInterface
+     */
+    protected $exceptionStrategyManager;
+
+    /**
+     * @var LoggerInterface|null
      */
     protected $logger;
 
@@ -28,20 +43,19 @@ class BlockRenderer implements BlockRendererInterface
     protected $debug;
 
     /**
-     * @var BlockServiceManagerInterface
+     * Constructor
+     *
+     * @param BlockServiceManagerInterface $blockServiceManager      Block service manager
+     * @param StrategyManagerInterface     $exceptionStrategyManager Exception strategy manager
+     * @param LoggerInterface              $logger                   Logger class
+     * @param boolean                      $debug                    Whether in debug mode or not
      */
-    protected $blockServiceManager;
-
-    /**
-     * @param BlockServiceManagerInterface $blockServiceManager
-     * @param LoggerInterface $logger
-     * @param boolean $debug
-     */
-    public function __construct(BlockServiceManagerInterface $blockServiceManager, LoggerInterface $logger, $debug)
+    public function __construct(BlockServiceManagerInterface $blockServiceManager, StrategyManagerInterface $exceptionStrategyManager, LoggerInterface $logger = null, $debug = false)
     {
-        $this->debug  = $debug;
-        $this->logger = $logger;
-        $this->blockServiceManager = $blockServiceManager;
+        $this->blockServiceManager      = $blockServiceManager;
+        $this->exceptionStrategyManager = $exceptionStrategyManager;
+        $this->logger                   = $logger;
+        $this->debug                    = $debug;
     }
 
     /**
@@ -55,28 +69,20 @@ class BlockRenderer implements BlockRendererInterface
 
         try {
             $service = $this->blockServiceManager->get($block);
+            $service->load($block);
+            $newResponse = $service->execute($block, $response);
 
-            $service->load($block); // load the block
-
-            $response = $service->execute($block, $response);
-
-            if (!$response instanceof Response) {
+            if (!$newResponse instanceof Response) {
                 throw new \RuntimeException('A block service must return a Response object');
             }
 
-        } catch (\Exception $e) {
+        } catch (\Exception $exception) {
             if ($this->logger) {
-                $this->logger->crit(sprintf('[cms::renderBlock] block.id=%d - error while rendering block - %s', $block->getId(), $e->getMessage()));
+                $this->logger->crit(sprintf('[cms::renderBlock] block.id=%d - error while rendering block - %s', $block->getId(), $exception->getMessage()));
             }
-
-            if ($this->debug) {
-                throw $e;
-            }
-
-            $response = new Response;
-            $response->setPrivate();
+            $newResponse = $this->exceptionStrategyManager->handleException($exception, $block, $response);
         }
 
-        return $response;
+        return $newResponse;
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -62,6 +62,45 @@ class Configuration implements ConfigurationInterface
                             ->useAttributeAsKey('id')
                             ->prototype('scalar')->end()
                         ->end()
+                        ->arrayNode('exception')
+                            ->children()
+                                ->scalarNode('filter')  ->defaultValue(null)->end()
+                                ->scalarNode('renderer')->defaultValue(null)->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+
+            ->arrayNode('exception')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->arrayNode('default')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->scalarNode('filter')  ->defaultValue('debug_only')->end()
+                            ->scalarNode('renderer')->defaultValue('throw')->end()
+                        ->end()
+                    ->end()
+
+                    ->arrayNode('filters')
+                        ->useAttributeAsKey('id')
+                        ->prototype('scalar')->end()
+                        ->defaultValue(array(
+                            'debug_only'             => 'sonata.block.exception.filter.debug_only',
+                            'ignore_block_exception' => 'sonata.block.exception.filter.ignore_block_exception',
+                            'keep_all'               => 'sonata.block.exception.filter.keep_all',
+                            'keep_none'              => 'sonata.block.exception.filter.keep_none',
+                        ))
+                    ->end()
+                    ->arrayNode('renderers')
+                        ->useAttributeAsKey('id')
+                        ->prototype('scalar')->end()
+                        ->defaultValue(array(
+                            'inline'                 => 'sonata.block.exception.renderer.inline',
+                            'inline_debug'           => 'sonata.block.exception.renderer.inline_debug',
+                            'throw'                  => 'sonata.block.exception.renderer.throw',
+                        ))
                     ->end()
                 ->end()
             ->end()

--- a/Exception/BlockExceptionInterface.php
+++ b/Exception/BlockExceptionInterface.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception;
+
+/**
+ * Interface to implement exception identified as block-specific exceptions
+ */
+interface BlockExceptionInterface
+{
+}

--- a/Exception/Filter/DebugOnlyFilter.php
+++ b/Exception/Filter/DebugOnlyFilter.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception\Filter;
+
+use Symfony\Component\HttpFoundation\Response;
+use Sonata\BlockBundle\Model\BlockInterface;
+
+/**
+ * This filter handles exceptions only when debug mode is enabled.
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class DebugOnlyFilter implements FilterInterface
+{
+    /**
+     * @var boolean
+     */
+    protected $debug;
+
+    /**
+     * Constructor
+     *
+     * @param boolean $debug
+     */
+    public function __construct($debug)
+    {
+        $this->debug = $debug;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(\Exception $exception, BlockInterface $block)
+    {
+        return $this->debug ? true : false;
+    }
+}

--- a/Exception/Filter/FilterInterface.php
+++ b/Exception/Filter/FilterInterface.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception\Filter;
+
+use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Interface for the exception filter used in the exception strategy management.
+ *
+ * It's purpose is to define which exceptions should be managed and which should simply be ignored.
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+interface FilterInterface
+{
+    /**
+     * Returns whether or not this filter handles this exception for given block
+     *
+     * @param \Exception     $exception Exception to manage
+     * @param BlockInterface $block     Block that provoked the exception
+     *
+     * @return boolean
+     */
+    public function handle(\Exception $exception, BlockInterface $block);
+}

--- a/Exception/Filter/IgnoreClassFilter.php
+++ b/Exception/Filter/IgnoreClassFilter.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception\Filter;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+
+/**
+ * This filter ignores exceptions that inherit a given class or interface, or in other words, it will only handle
+ * exceptions that do not inherit the given class or interface.
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class IgnoreClassFilter implements FilterInterface
+{
+    /**
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * Constructor
+     *
+     * @param string $class
+     */
+    public function __construct($class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(\Exception $exception, BlockInterface $block)
+    {
+        return (!$exception instanceof $this->class);
+    }
+}

--- a/Exception/Filter/KeepAllFilter.php
+++ b/Exception/Filter/KeepAllFilter.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception\Filter;
+
+use Symfony\Component\HttpFoundation\Response;
+use Sonata\BlockBundle\Model\BlockInterface;
+
+/**
+ * This filter will handle all exceptions
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class KeepAllFilter implements FilterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(\Exception $exception, BlockInterface $block)
+    {
+        return true;
+    }
+}

--- a/Exception/Filter/KeepNoneFilter.php
+++ b/Exception/Filter/KeepNoneFilter.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception\Filter;
+
+use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * This filters will ignore all exceptions.
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class KeepNoneFilter implements FilterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(\Exception $exception, BlockInterface $block)
+    {
+        return false;
+    }
+}

--- a/Exception/Renderer/InlineDebugRenderer.php
+++ b/Exception/Renderer/InlineDebugRenderer.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception\Renderer;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Templating\EngineInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+
+use Symfony\Component\HttpKernel\Exception\FlattenException;
+
+/**
+ * This renderer uses a template to display an error message at the block position with extensive debug information.
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class InlineDebugRenderer implements RendererInterface
+{
+    /**
+     * @var EngineInterface
+     */
+    protected $templating;
+
+    /**
+     * @var string
+     */
+    protected $template;
+
+    /**
+     * @var boolean
+     */
+    protected $forceStyle;
+
+    /**
+     * @var boolean
+     */
+    protected $debug;
+
+    /**
+     * Constructor
+     *
+     * @param EngineInterface $templating Templating engine
+     * @param string          $template   Template to render
+     * @param boolean         $debug      Whether the debug is enabled or not
+     * @param boolean         $forceStyle Whether to force style within the template or not
+     */
+    public function __construct(EngineInterface $templating, $template, $debug, $forceStyle = true)
+    {
+        $this->templating = $templating;
+        $this->template   = $template;
+        $this->debug      = $debug;
+        $this->forceStyle = $forceStyle;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(\Exception $exception, BlockInterface $block, Response $response = null)
+    {
+        $response = $response ?: new Response();
+
+        // enforce debug mode or ignore silently
+        if (!$this->debug) {
+            return $response;
+        }
+
+        $flattenException = FlattenException::create($exception);
+        $code = $flattenException->getStatusCode();
+
+        $parameters = array(
+            'exception'      => $flattenException,
+            'status_code'    => $code,
+            'status_text'    => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',
+            'logger'         => false,
+            'currentContent' => false,
+            'block'          => $block,
+            'forceStyle'     => $this->forceStyle
+        );
+
+        $content = $this->templating->render($this->template, $parameters);
+        $response->setContent($content);
+
+        return $response;
+    }
+}

--- a/Exception/Renderer/InlineRenderer.php
+++ b/Exception/Renderer/InlineRenderer.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception\Renderer;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Templating\EngineInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+
+/**
+ * This renderer uses a template to display an error message at the block position
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class InlineRenderer implements RendererInterface
+{
+    /**
+     * @var EngineInterface
+     */
+    protected $templating;
+
+    /**
+     * @var string
+     */
+    protected $template;
+
+    /**
+     * Constructor
+     *
+     * @param EngineInterface $templating Templating engine
+     * @param string          $template   Template to render
+     */
+    public function __construct(EngineInterface $templating, $template)
+    {
+        $this->templating = $templating;
+        $this->template   = $template;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(\Exception $exception, BlockInterface $block, Response $response = null)
+    {
+        $parameters = array(
+            'exception'      => $exception,
+            'block'          => $block
+        );
+
+        $content = $this->templating->render($this->template, $parameters);
+
+        $response = $response ?: new Response();
+        $response->setContent($content);
+
+        return $response;
+    }
+}

--- a/Exception/Renderer/MonkeyThrowRenderer.php
+++ b/Exception/Renderer/MonkeyThrowRenderer.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception\Renderer;
+
+use Symfony\Component\HttpFoundation\Response;
+use Sonata\BlockBundle\Model\BlockInterface;
+
+/**
+ * This renderer re-throws the exception and lets the framework handle the exception
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class MonkeyThrowRenderer implements RendererInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function render(\Exception $banana, BlockInterface $block, Response $response = null)
+    {
+        throw $banana;
+    }
+}

--- a/Exception/Renderer/RendererInterface.php
+++ b/Exception/Renderer/RendererInterface.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception\Renderer;
+
+use Symfony\Component\HttpFoundation\Response;
+use Sonata\BlockBundle\Model\BlockInterface;
+
+/**
+ * Interface for exception renderer
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+interface RendererInterface
+{
+    /**
+     * Renders an exception into an HTTP response
+     *
+     * @param \Exception     $exception Exception provoked
+     * @param BlockInterface $block     Block that provoked the exception
+     * @param Response       $response  Response to alter
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function render(\Exception $exception, BlockInterface $block, Response $response = null);
+}

--- a/Exception/Strategy/StrategyManager.php
+++ b/Exception/Strategy/StrategyManager.php
@@ -1,0 +1,212 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception\Strategy;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\BlockBundle\Exception\Renderer\RendererInterface;
+use Sonata\BlockBundle\Exception\Filter\FilterInterface;
+
+/**
+ * The strategy manager handles exceptions thrown by a block. It uses an exception filter to identify which exceptions
+ * it should handle or ignore. It then uses an exception renderer to "somehow" display the exception.
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class StrategyManager implements StrategyManagerInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var array
+     */
+    protected $filters;
+
+    /**
+     * @var array
+     */
+    protected $renderers;
+
+    /**
+     * @var array
+     */
+    protected $blockFilters;
+
+    /**
+     * @var array
+     */
+    protected $blockRenderers;
+
+    /**
+     * @var string
+     */
+    protected $defaultFilter;
+
+    /**
+     * @var string
+     */
+    protected $defaultRenderer;
+
+    /**
+     * Constructor
+     *
+     * @param ContainerInterface $container      Dependency injection container
+     * @param array              $filters        Filter definitions
+     * @param array              $renderers      Renderer definitions
+     * @param array              $blockFilters   Filter names for each block
+     * @param array              $blockRenderers Renderer names for each block
+     */
+    public function __construct(ContainerInterface $container, array $filters, array $renderers, array $blockFilters, array $blockRenderers)
+    {
+        $this->container      = $container;
+        $this->filters        = $filters;
+        $this->renderers      = $renderers;
+        $this->blockFilters   = $blockFilters;
+        $this->blockRenderers = $blockRenderers;
+    }
+
+    /**
+     * Sets the default filter name
+     *
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function setDefaultFilter($name)
+    {
+        if (!array_key_exists($name, $this->filters)) {
+            throw new \InvalidArgumentException(sprintf('Cannot set default exception filter "%s". It does not exists.', $name));
+        }
+
+        $this->defaultFilter = $name;
+    }
+
+    /**
+     * Sets the default renderer name
+     *
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function setDefaultRenderer($name)
+    {
+        if (!array_key_exists($name, $this->renderers)) {
+            throw new \InvalidArgumentException(sprintf('Cannot set default exception renderer "%s". It does not exists.', $name));
+        }
+
+        $this->defaultRenderer = $name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleException(\Exception $exception, BlockInterface $block, Response $response = null)
+    {
+        $response = $response ?: new Response();
+        $response->setPrivate();
+
+        $filter = $this->getBlockFilter($block);
+        if ($filter->handle($exception, $block)) {
+            $renderer = $this->getBlockRenderer($block);
+            $response = $renderer->render($exception, $block, $response);
+        } else {
+            // render empty block template?
+        }
+
+        return $response;
+    }
+
+    /**
+     * Returns the exception renderer for given block
+     *
+     * @param BlockInterface $block
+     *
+     * @return RendererInterface
+     *
+     * @throws \RuntimeException
+     */
+    public function getBlockRenderer(BlockInterface $block)
+    {
+        $type = $block->getType();
+
+        $name = isset($this->blockRenderers[$type]) ? $this->blockRenderers[$type] : $this->defaultRenderer;
+        $service = $this->getRendererService($name);
+
+        if (!$service instanceof RendererInterface) {
+            throw new \RuntimeException(sprintf('The service "%s" is not an exception renderer', $name));
+        }
+
+        return $service;
+    }
+
+    /**
+     * Returns the exception filter for given block
+     *
+     * @param BlockInterface $block
+     *
+     * @return FilterInterface
+     *
+     * @throws \RuntimeException
+     */
+    public function getBlockFilter(BlockInterface $block)
+    {
+        $type = $block->getType();
+
+        $name = isset($this->blockFilters[$type]) ? $this->blockFilters[$type] : $this->defaultFilter;
+        $service = $this->getFilterService($name);
+
+        if (!$service instanceof FilterInterface) {
+            throw new \RuntimeException(sprintf('The service "%s" is not an exception filter', $name));
+        }
+
+        return $service;
+    }
+
+    /**
+     * Returns the filter service for given filter name
+     *
+     * @param string $name
+     *
+     * @return object
+     *
+     * @throws \RuntimeException
+     */
+    protected function getFilterService($name)
+    {
+        if (!isset($this->filters[$name])) {
+            throw new \RuntimeException('The filter "%s" does not exists.');
+        }
+
+        return $this->container->get($this->filters[$name]);
+    }
+
+    /**
+     * Returns the renderer service for given renderer name
+     *
+     * @param string $name
+     *
+     * @return object
+     *
+     * @throws \RuntimeException
+     */
+    protected  function getRendererService($name)
+    {
+        if (!isset($this->renderers[$name])) {
+            throw new \RuntimeException('The renderer "%s" does not exists.');
+        }
+
+        return $this->container->get($this->renderers[$name]);
+    }
+}

--- a/Exception/Strategy/StrategyManagerInterface.php
+++ b/Exception/Strategy/StrategyManagerInterface.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Exception\Strategy;
+
+use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Interface for exception strategy management
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+interface StrategyManagerInterface
+{
+    /**
+     * Handles an exception for a given block
+     *
+     * @param \Exception     $exception Exception to handle
+     * @param BlockInterface $block     Block that provoked the exception
+     * @param Response       $response  Response provided to the block service
+     *
+     * @return Response
+     */
+    function handleException(\Exception $exception, BlockInterface $block, Response $response = null);
+}

--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -13,6 +13,7 @@
 
         <service id="sonata.block.renderer" class="Sonata\BlockBundle\Block\BlockRenderer">
             <argument type="service" id="sonata.block.manager" />
+            <argument type="service" id="sonata.block.exception.strategy.manager" />
             <argument type="service" id="logger"  on-invalid="ignore"  />
             <argument>%kernel.debug%</argument>
         </service>

--- a/Resources/config/exception.xml
+++ b/Resources/config/exception.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sonata.block.exception.strategy.manager.class">Sonata\BlockBundle\Exception\Strategy\StrategyManager</parameter>
+    </parameters>
+
+    <services>
+
+        <!-- exception strategy manager -->
+        <service id="sonata.block.exception.strategy.manager" class="%sonata.block.exception.strategy.manager.class%">
+            <argument type="service" id="service_container" />
+            <argument type="collection"/>
+            <argument type="collection"/>
+            <argument type="collection"/>
+            <argument type="collection"/>
+        </service>
+
+        <!-- exception filters -->
+        <service id="sonata.block.exception.filter.keep_none"  class="Sonata\BlockBundle\Exception\Filter\KeepNoneFilter"/>
+        <service id="sonata.block.exception.filter.keep_all"   class="Sonata\BlockBundle\Exception\Filter\KeepAllFilter"/>
+        <service id="sonata.block.exception.filter.debug_only" class="Sonata\BlockBundle\Exception\Filter\DebugOnlyFilter">
+            <argument>%kernel.debug%</argument>
+        </service>
+        <service id="sonata.block.exception.filter.ignore_block_exception" class="Sonata\BlockBundle\Exception\Filter\IgnoreClassFilter">
+            <argument>Sonata\BlockBundle\Exception\BlockExceptionInterface</argument>
+        </service>
+
+        <!-- exception renderers -->
+        <service id="sonata.block.exception.renderer.inline" class="Sonata\BlockBundle\Exception\Renderer\InlineRenderer">
+            <argument type="service" id="templating" />
+            <argument>SonataBlockBundle:Block:block_exception.html.twig</argument>
+        </service>
+
+        <service id="sonata.block.exception.renderer.inline_debug" class="Sonata\BlockBundle\Exception\Renderer\InlineDebugRenderer">
+            <argument type="service" id="templating" />
+            <argument>SonataBlockBundle:Block:block_exception_debug.html.twig</argument>
+            <argument>%kernel.debug%</argument>
+            <argument>true</argument>
+        </service>
+
+        <service id="sonata.block.exception.renderer.throw" class="Sonata\BlockBundle\Exception\Renderer\MonkeyThrowRenderer"/>
+
+    </services>
+</container>

--- a/Resources/doc/reference/exceptions.rst
+++ b/Resources/doc/reference/exceptions.rst
@@ -1,0 +1,83 @@
+Exception strategy
+==================
+
+Any exception thrown by a block service is handled by an exception strategy manager that
+determines how the exception should be handled. A default strategy can be defined for all
+block types but a specific strategy can also be defined on a per block type basis.
+
+The exception strategy uses an exception filter and an exception renderer.
+
+Filters
+-------
+
+The role of an exception filter is to define which exceptions should be handled and which
+should be ignored silently. There are currently 4 filters available:
+
+    - Debug only: only handle exceptions when in debug mode. (default)
+    - Ignore block exception: only handle exceptions that don't implement ``BlockExceptionInterface``
+    - Keep all: handle all exceptions
+    - Keep non: ignore all exceptions (use with care)
+
+These filters may be modified or completed with others filters in the configuration file:
+
+.. code-block:: yaml
+
+    #config.yml
+    sonata_block:
+        exception:
+            default:
+                filter:                     debug_only
+            filters:
+                debug_only:             sonata.block.exception.filter.debug_only
+                ignore_block_exception: sonata.block.exception.filter.ignore_block_exception
+                keep_all:               sonata.block.exception.filter.keep_all
+                keep_none:              sonata.block.exception.filter.keep_none
+
+A default filter may be configure to apply, by default, to all block types. If you wish to
+customize a filter on a particular block type, you may also add the following option in the
+configuration file:
+
+.. code-block:: yaml
+
+    #config.yml
+    sonata_block:
+        blocks:
+            sonata.block.service.text:
+                exception: { filter: keep_all }
+
+Renderers
+---------
+
+The role of an exception renderer is to define what to do with the exceptions that have passed
+the filter. There are currently 2 renderers available:
+
+    - inline: renders a twig template within the rendering workflow with minimal information regarding the exception.
+    - inline_debug: renders a twig template with the full debug exception information from symfony.
+    - throw: throws the exception to let the framework handle the exception.
+
+These filters may be modified or completed with others filters in the configuration file:
+
+.. code-block:: yaml
+
+    #config.yml
+    sonata_block:
+        exception:
+            default:
+                renderer:               throw
+            renderers:
+                inline:                 sonata.block.exception.renderer.inline
+                inline_debug:           sonata.block.exception.renderer.inline_debug
+                throw:                  sonata.block.exception.renderer.throw
+
+
+A default renderer may be configure to apply, by default, to all block types. If you wish to
+customize a renderer on a particular block type, you may also add the following option in the
+configuration file:
+
+.. code-block:: yaml
+
+    #config.yml
+    sonata_block:
+        blocks:
+            sonata.block.service.text:
+                exception: { renderer: inline }

--- a/Resources/views/Block/block_exception.html.twig
+++ b/Resources/views/Block/block_exception.html.twig
@@ -1,0 +1,19 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends sonata_block.templates.block_base %}
+
+{% block block %}
+    <div class="cms-block-exception">
+        <h2>{{ block.name }}</h2>
+        <h3>{{ exception.message }}</h3>
+    </div>
+{% endblock %}

--- a/Resources/views/Block/block_exception_debug.html.twig
+++ b/Resources/views/Block/block_exception_debug.html.twig
@@ -1,0 +1,24 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends sonata_block.templates.block_base %}
+
+{% block block %}
+    <div class="cms-block-exception" {% if forceStyle %}style="overflow-y: scroll; min-width: 300px; max-height: 300px;"{% endif %}>
+
+        {# this is dirty but the alternative would require a new block-optimized exception css #}
+        {% if forceStyle %}
+            <link href="{{ asset('bundles/framework/css/exception_layout.css') }}" rel="stylesheet" type="text/css" media="all" />
+            <link href="{{ asset('bundles/framework/css/exception.css') }}" rel="stylesheet" type="text/css" media="all" />
+        {% endif %}
+        {% include 'TwigBundle:Exception:exception.html.twig' %}
+    </div>
+{% endblock %}

--- a/Tests/Block/BlockRendererTest.php
+++ b/Tests/Block/BlockRendererTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Block;
+
+use Sonata\BlockBundle\Block\BlockRenderer;
+
+/**
+ * Unit test of BlockRenderer class
+ */
+class BlockRendererTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Sonata\BlockBundle\Block\BlockServiceManagerInterface
+     */
+    protected $blockServiceManager;
+
+    /**
+     * @var \Symfony\Component\HttpKernel\Log\LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var \Sonata\BlockBundle\Exception\Strategy\StrategyManager
+     */
+    protected $exceptionStrategyManager;
+
+    /**
+     * @var BlockRenderer
+     */
+    protected $renderer;
+
+    /**
+     * Setup test object
+     */
+    public function setUp()
+    {
+        $this->blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $this->exceptionStrategyManager = $this->getMock('Sonata\BlockBundle\Exception\Strategy\StrategyManagerInterface');
+        $this->logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
+
+        $this->renderer = new BlockRenderer($this->blockServiceManager, $this->exceptionStrategyManager, $this->logger);
+    }
+
+    /**
+     * Test rendering a block without errors
+     */
+    public function testRenderWithoutErrors()
+    {
+        // GIVEN
+
+        // mock a block service that returns a response
+        $response = $this->getMock('Symfony\Component\HttpFoundation\Response');
+        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $service->expects($this->once())->method('load');
+        $service->expects($this->once())->method('execute')->will($this->returnValue($response));
+        $this->blockServiceManager->expects($this->once())->method('get')->will($this->returnValue($service));
+
+        // mock a block object
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+
+        // WHEN
+        $result = $this->renderer->render($block);
+
+        // THEN
+        $this->assertEquals($response, $result, 'Should return the response from the block service');
+    }
+
+    /**
+     * Test rendering a block that returns a wrong response
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage A block service must return a Response object
+     */
+    public function testRenderWithWrongResponse()
+    {
+        // GIVEN
+
+        // mock a block service that returns a string response
+        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $service->expects($this->once())->method('load');
+        $service->expects($this->once())->method('execute')->will($this->returnValue('wrong response'));
+        $this->blockServiceManager->expects($this->once())->method('get')->will($this->returnValue($service));
+
+        // mock the exception strategy manager to rethrow the exception
+        $this->exceptionStrategyManager->expects($this->once())
+            ->method('handleException')
+            ->will($this->returnCallback(function($e) {
+                throw $e;
+            }));
+
+        // mock the logger to ensure a crit message is logged
+        $this->logger->expects($this->once())->method('crit');
+
+        // mock a block object
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+
+        // WHEN
+        $this->renderer->render($block);
+
+        // THEN
+        // exception thrown
+    }
+
+    /**
+     * Test rendering a block that throws an exception
+     */
+    public function testRenderBlockWithException()
+    {
+        // GIVEN
+
+        // mock a block service that throws an user exception
+        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $service->expects($this->once())->method('load');
+
+        $exception = $this->getMock('\Exception');
+        $service->expects($this->once())
+            ->method('execute')
+            ->will($this->returnCallback(function() use ($exception) {
+                throw $exception;
+            }));
+
+        $this->blockServiceManager->expects($this->once())->method('get')->will($this->returnValue($service));
+
+        // mock the exception strategy manager to return a response when given the correct exception
+        $response = $this->getMock('Symfony\Component\HttpFoundation\Response');
+        $this->exceptionStrategyManager->expects($this->once())
+            ->method('handleException')
+            ->with($this->equalTo($exception))
+            ->will($this->returnValue($response));
+
+        // mock the logger to ensure a crit message is logged
+        $this->logger->expects($this->once())->method('crit');
+
+        // mock a block object
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+
+        // WHEN
+        $result = $this->renderer->render($block);
+
+        // THEN
+        $this->assertEquals($response, $result, 'Should return the response provider by the exception manager');
+    }
+}

--- a/Tests/Exception/Filter/DebugOnlyFilterTest.php
+++ b/Tests/Exception/Filter/DebugOnlyFilterTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Exception\Renderer;
+
+use Sonata\BlockBundle\Exception\Filter\DebugOnlyFilter;
+
+/**
+ * Test the debug only exception filter
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class DebugOnlyFilterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * test the filter with debug enabled
+     */
+    public function testWithDebugEnabled()
+    {
+        // GIVEN
+        $exception = $this->getMock('\Exception');
+        $block     = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $filter = new DebugOnlyFilter(true);
+
+        // WHEN
+        $result = $filter->handle($exception, $block);
+
+        // THEN
+        $this->assertTrue($result, 'Should handle it since we have enabled debug');
+    }
+
+    /**
+     * test the filter with debug disabled
+     */
+    public function testWithDebugDisabled()
+    {
+        // GIVEN
+        $exception = $this->getMock('\Exception');
+        $block     = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $filter = new DebugOnlyFilter(false);
+
+        // WHEN
+        $result = $filter->handle($exception, $block);
+
+        // THEN
+        $this->assertFalse($result, 'Should NOT handle it since we have disabled debug');
+    }
+}

--- a/Tests/Exception/Filter/IgnoreClassFilterTest.php
+++ b/Tests/Exception/Filter/IgnoreClassFilterTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Exception\Renderer;
+
+use Sonata\BlockBundle\Exception\Filter\IgnoreClassFilter;
+
+/**
+ * Test the ignore class exception filter
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class IgnoreClassFilterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * test the filter with a inherited exception
+     */
+    public function testWithInheritedException()
+    {
+        // GIVEN
+        $exception = $this->getMock('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $block     = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $filter = new IgnoreClassFilter('\RuntimeException');
+
+        // WHEN
+        $result = $filter->handle($exception, $block);
+
+        // THEN
+        $this->assertFalse($result, 'Should NOT handle it since NotFoundHttpException inherits RuntimeException');
+    }
+
+    /**
+     * test the the filter with a non-inherited exception
+     */
+    public function testWithNonInheritedException()
+    {
+        // GIVEN
+        $exception = $this->getMock('\Exception');
+        $block     = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $filter = new IgnoreClassFilter('\RuntimeException');
+
+        // WHEN
+        $result = $filter->handle($exception, $block);
+
+        // THEN
+        $this->assertTrue($result, 'Should handle it since an \Exception does not inherit RuntimeException');
+    }
+}

--- a/Tests/Exception/Filter/KeepAllFilterTest.php
+++ b/Tests/Exception/Filter/KeepAllFilterTest.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Exception\Renderer;
+
+use Sonata\BlockBundle\Exception\Filter\KeepAllFilter;
+
+/**
+ * Test the keep all exception filter
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class KeepAllFilterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * test the filter with an exception
+     *
+     * @param \Exception $exception
+     *
+     * @dataProvider getExceptions
+     */
+    public function testFilter(\Exception $exception)
+    {
+        // GIVEN
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $filter = new KeepAllFilter();
+
+        // WHEN
+        $result = $filter->handle($exception, $block);
+
+        // THEN
+        $this->assertTrue($result, 'Should handle any exception');
+    }
+
+    /**
+     * Returns exceptions to test
+     *
+     * @return array
+     */
+    public function getExceptions()
+    {
+        return array(
+            array($this->getMock('\Exception')),
+            array($this->getMock('\RuntimeException'))
+        );
+    }
+}

--- a/Tests/Exception/Filter/KeepNoneFilterTest.php
+++ b/Tests/Exception/Filter/KeepNoneFilterTest.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Exception\Renderer;
+
+use Sonata\BlockBundle\Exception\Filter\KeepNoneFilter;
+
+/**
+ * Test the keep all exception filter
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class KeepNoneFilterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * test the filter with an exception
+     *
+     * @param \Exception $exception
+     *
+     * @dataProvider getExceptions
+     */
+    public function testFilter(\Exception $exception)
+    {
+        // GIVEN
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $filter = new KeepNoneFilter();
+
+        // WHEN
+        $result = $filter->handle($exception, $block);
+
+        // THEN
+        $this->assertFalse($result, 'Should handle no exceptions');
+    }
+
+    /**
+     * Returns exceptions to test
+     *
+     * @return array
+     */
+    public function getExceptions()
+    {
+        return array(
+            array($this->getMock('\Exception')),
+            array($this->getMock('\RuntimeException'))
+        );
+    }
+}

--- a/Tests/Exception/Renderer/InlineDebugRendererTest.php
+++ b/Tests/Exception/Renderer/InlineDebugRendererTest.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Exception\Renderer;
+
+use Sonata\BlockBundle\Exception\Renderer\InlineDebugRenderer;
+
+/**
+ * Test the inline debug exception renderer
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class InlineDebugRendererTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * test the renderer without debug mode
+     */
+    public function testRenderWithoutDebug()
+    {
+        // GIVEN
+        $template   = 'test-template';
+        $debug      = false;
+        $exception  = $this->getMock('\Exception');
+        $block      = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+
+        $renderer = new InlineDebugRenderer($templating, $template, $debug);
+
+        // WHEN
+        $response = $renderer->render($exception, $block);
+
+        // THEN
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response, 'Should return a Response');
+        $this->assertEmpty($response->getContent(), 'Should have no content');
+    }
+
+    /**
+     * test the render() method with debug enabled
+     */
+    public function testRenderWithDebugEnabled()
+    {
+        // GIVEN
+        $template = 'test-template';
+        $debug    = true;
+
+        // mock an exception to render
+        $exception = $this->getMock('\Exception');
+
+        // mock a block instance that provoked the exception
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+
+        // mock the templating render() to return an html result
+        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo($template),
+                $this->logicalAnd(
+                    $this->arrayHasKey('exception'),
+                    $this->arrayHasKey('status_code'),
+                    $this->arrayHasKey('status_text'),
+                    $this->arrayHasKeyValue('logger', false),
+                    $this->arrayHasKeyValue('currentContent', false),
+                    $this->arrayHasKeyValue('block', $block),
+                    $this->arrayHasKeyValue('forceStyle', true)
+                )
+            )
+            ->will($this->returnValue('html'));
+
+        // create renderer to test
+        $renderer = new InlineDebugRenderer($templating, $template, $debug);
+
+        // WHEN
+        $response = $renderer->render($exception, $block);
+
+        // THEN
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response, 'Should return a Response');
+        $this->assertEquals('html', $response->getContent(), 'Should contain the templating html result');
+    }
+
+    /**
+     * Returns a PHPUnit Constraint that ensures that an array has a key with given value
+     *
+     * @param mixed $key   Key to be found in array
+     * @param mixed $value Value to be found in array
+     *
+     * @return \PHPUnit_Framework_Constraint_Callback
+     */
+    public function arrayHasKeyValue($key, $value)
+    {
+        return new \PHPUnit_Framework_Constraint_Callback(function($test) use ($key, $value) {
+            return (is_array($test) && array_key_exists($key, $test) && $test[$key] === $value);
+        });
+    }
+}

--- a/Tests/Exception/Renderer/InlineRendererTest.php
+++ b/Tests/Exception/Renderer/InlineRendererTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Exception\Renderer;
+
+use Sonata\BlockBundle\Exception\Renderer\InlineRenderer;
+
+/**
+ * Test the inline exception renderer
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class InlineRendererTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * test the render() method
+     */
+    public function testRender()
+    {
+        // GIVEN
+        $template = 'test-template';
+
+        // mock an exception to render
+        $exception = $this->getMock('\Exception');
+
+        // mock a block instance that provoked the exception
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+
+        // mock the templating render() to return an html result
+        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo($template),
+                $this->equalTo(array(
+                    'exception' => $exception,
+                    'block' => $block))
+            )
+            ->will($this->returnValue('html'));
+
+        // create renderer to test
+        $renderer = new InlineRenderer($templating, $template);
+
+        // WHEN
+        $response = $renderer->render($exception, $block);
+
+        // THEN
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response, 'Should return a Response');
+        $this->assertEquals('html', $response->getContent(), 'Should contain the templating html result');
+    }
+}

--- a/Tests/Exception/Renderer/MonkeyThrowRendererTest.php
+++ b/Tests/Exception/Renderer/MonkeyThrowRendererTest.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Exception\Renderer;
+
+use Sonata\BlockBundle\Exception\Renderer\MonkeyThrowRenderer;
+
+/**
+ * Test the monkey throw exception renderer
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class MonkeyThrowRendererTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * test the render() method with a standard Exception
+     *
+     * @expectedException \Exception
+     */
+    public function testRenderWithStandardException()
+    {
+        // GIVEN
+        $exception = new \Exception;
+        $block     = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $renderer  = new MonkeyThrowRenderer();
+
+        // WHEN
+        $renderer->render($exception, $block);
+
+        // THEN
+        // exception expected
+    }
+
+    /**
+     * test the render() method with another exception to ensure it correctly throws the provided exception
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testRenderWithRuntimeException()
+    {
+        // GIVEN
+        $exception = new \RuntimeException();
+        $block     = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $renderer  = new MonkeyThrowRenderer();
+
+        // WHEN
+        $renderer->render($exception, $block);
+
+        // THEN
+        // exception expected
+    }
+}

--- a/Tests/Exception/Strategy/StrategyManagerTest.php
+++ b/Tests/Exception/Strategy/StrategyManagerTest.php
@@ -1,0 +1,251 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Exception\Strategy;
+
+use Sonata\BlockBundle\Exception\Strategy\StrategyManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Test the Exception Strategy Manager
+ *
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+class StrategyManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var StrategyManager
+     */
+    protected $manager;
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var array
+     */
+    protected $filters = array();
+
+    /**
+     * @var array
+     */
+    protected $renderers = array();
+
+    /**
+     * @var array
+     */
+    protected $blockFilters = array();
+
+    /**
+     * @var array
+     */
+    protected $blockRenderers = array();
+
+    /**
+     * @var \Sonata\BlockBundle\Exception\Renderer\RendererInterface
+     */
+    protected $renderer1;
+
+    /**
+     * @var \Sonata\BlockBundle\Exception\Renderer\RendererInterface
+     */
+    protected $renderer2;
+
+    /**
+     * @var \Sonata\BlockBundle\Exception\Filter\FilterInterface
+     */
+    protected $filter1;
+
+    /**
+     * @var \Sonata\BlockBundle\Exception\Filter\FilterInterface
+     */
+    protected $filter2;
+
+    /**
+     * setup a basic scenario to avoid long test setup
+     */
+    public function setUp()
+    {
+        $this->renderer1 = $this->getMock('\Sonata\BlockBundle\Exception\Renderer\RendererInterface');
+        $this->renderer2 = $this->getMock('\Sonata\BlockBundle\Exception\Renderer\RendererInterface');
+        $this->filter1   = $this->getMock('\Sonata\BlockBundle\Exception\Filter\FilterInterface');
+        $this->filter2   = $this->getMock('\Sonata\BlockBundle\Exception\Filter\FilterInterface');
+
+        // setup a mock container which contains our mock renderers and filters
+        $this->container = $this->getMockContainer(array(
+            'service.renderer1' => $this->renderer1,
+            'service.renderer2' => $this->renderer2,
+            'service.filter1'   => $this->filter1,
+            'service.filter2'   => $this->filter2,
+        ));
+
+        // setup 2 mock renderers
+        $this->renderers = array();
+        $this->renderers['renderer1'] = 'service.renderer1';
+        $this->renderers['renderer2'] = 'service.renderer2';
+
+        // setup 2 mock filters
+        $this->filters = array();
+        $this->filters['filter1'] = 'service.filter1';
+        $this->filters['filter2'] = 'service.filter2';
+
+        // setup a specific filter and renderer for "type1" blocks
+        $this->blockFilters = array('block.type1' => 'filter2');
+        $this->blockRenderers = array('block.type1' => 'renderer2');
+
+        // create test object
+        $this->manager = new StrategyManager($this->container, $this->filters, $this->renderers, $this->blockFilters, $this->blockRenderers);
+
+        // setup default filters and renderers in manager
+        $this->manager->setDefaultFilter('filter1');
+        $this->manager->setDefaultRenderer('renderer1');
+    }
+
+    /**
+     * test getBlockRenderer() with existing block renderer
+     */
+    public function testGetBlockRendererWithExisting()
+    {
+        // GIVEN
+        $block = $this->getMockBlock('block.type1');
+
+        // WHEN
+        $renderer = $this->manager->getBlockRenderer($block);
+
+        // THEN
+        $this->assertNotNull($renderer);
+        $this->assertEquals($this->renderer2, $renderer, 'Should return the block type1 renderer');
+    }
+
+    /**
+     * test getBlockRenderer() with non existing block renderer
+     */
+    public function testGetBlockRendererWithNonExisting()
+    {
+        // GIVEN
+        $block = $this->getMockBlock('block.other_type');
+
+        // WHEN
+        $renderer = $this->manager->getBlockRenderer($block);
+
+        // THEN
+        $this->assertNotNull($renderer);
+        $this->assertEquals($this->renderer1, $renderer, 'Should return the default renderer');
+    }
+
+    /**
+     * test getBlockFilter() with an existing block filter
+     */
+    public function testGetBlockFilterWithExisting()
+    {
+        // GIVEN
+        $block = $this->getMockBlock('block.type1');
+
+        // WHEN
+        $filter = $this->manager->getBlockFilter($block);
+
+        // THEN
+        $this->assertNotNull($filter);
+        $this->assertEquals($this->filter2, $filter, 'Should return the block type1 filter');
+    }
+
+    /**
+     * test getting the default block renderer
+     */
+    public function testGetBlockFilterWithNonExisting()
+    {
+        // GIVEN
+        $block = $this->getMockBlock('block.other_type');
+
+        // WHEN
+        $filter = $this->manager->getBlockFilter($block);
+
+        // THEN
+        $this->assertNotNull($filter);
+        $this->assertEquals($this->filter1, $filter, 'Should return the default filter');
+    }
+
+    /**
+     * test handleException() with a keep none filter
+     */
+    public function testHandleExceptionWithKeepNoneFilter()
+    {
+        // GIVEN
+        $this->filter1->expects($this->once())->method('handle')->will($this->returnValue(false));
+        //$this->renderer1->expects($this->once())->method('render')->will($this->returnValue('renderer response'));
+
+        $exception = new \Exception();
+        $block = $this->getMockBlock('block.other_type');
+
+        // WHEN
+        $response = $this->manager->handleException($exception, $block);
+
+        // THEN
+        $this->assertNotNull($response, 'should return something');
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response, 'should return a response object');
+    }
+
+    /**
+     * test handleException() with a keep all filter
+     */
+    public function testHandleExceptionWithKeepAllFilter()
+    {
+        // GIVEN
+        $this->filter1->expects($this->once())->method('handle')->will($this->returnValue(true));
+        $this->renderer1->expects($this->once())->method('render')->will($this->returnValue('renderer response'));
+
+        $exception = new \Exception();
+        $block = $this->getMockBlock('block.other_type');
+
+        // WHEN
+        $response = $this->manager->handleException($exception, $block);
+
+        // THEN
+        $this->assertNotNull($response, 'should return something');
+        $this->assertEquals('renderer response', $response, 'should return the renderer response');
+    }
+
+    /**
+     * Returns a mock block model with given type
+     *
+     * @param string $type
+     *
+     * @return \Sonata\BlockBundle\Model\BlockInterface
+     */
+    protected function getMockBlock($type)
+    {
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block->expects($this->any())->method('getType')->will($this->returnValue($type));
+
+        return $block;
+    }
+
+    /**
+     * Returns a mock container with defined services
+     *
+     * @param array $services
+     *
+     * @return ContainerInterface
+     */
+    protected function getMockContainer(array $services = array())
+    {
+        $map = array();
+        foreach ($services as $name => $service) {
+            $map[] = array($name, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $service);
+        }
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container->expects($this->any())->method('get')->will($this->returnValueMap($map));
+
+        return $container;
+    }
+}


### PR DESCRIPTION
Currently, when not in debug mode, exceptions thrown in block services are completely ignored and are converted in blank blocks (no html). This may lead to unexpected behaviors in production since the page could end up being partially rendered.

In debug mode, all exceptions are thrown and managed by the framework with a full exception page. While the exception page is handy, it only shows the first exception encountered and hides the block composition of the page. This can sometimes be confusing if you want to have a more global view of the problems encountered on a page.

This feature proposes to implement an exception strategy management in order to give control on how exceptions thrown by block services should be managed.

The aim is to handle all exceptions thrown by block services, identify which exceptions should be managed with "exception filters", and show the exceptions through "exception renderers". Filters and renderers can be configured globally or on a per block-type basis, and it is easy to add new custom filters or custom renderers.

UPDATED:
- Fixed configuration issues: works out of the box.
