### PR TITLE
Update Block/BlockLoaderInterface.php

### DIFF
--- a/Block/BlockLoaderInterface.php
+++ b/Block/BlockLoaderInterface.php
@@ -16,7 +16,7 @@ interface BlockLoaderInterface
     /**
      * @param mixed $name
      *
-     * @return BlockLoaderInterface
+     * @return BlockLoaderInterface|null the block with that name or null if not found
      */
     function load($name);
 


### PR DESCRIPTION
If i understand it correctly, this is the semantics of the loader interface: if the block is not found, we return null rather than throw some exception. at least this is what the cmf loader does: https://github.com/symfony-cmf/BlockBundle/blob/master/Block/PHPCRBlockLoader.php#L41

/cc @elhornair
