### PR TITLE
Allowing cachable on dynamically created blocks (through twig helper).

### DIFF
--- a/Block/BlockRenderer.php
+++ b/Block/BlockRenderer.php
@@ -70,6 +70,13 @@ class BlockRenderer implements BlockRendererInterface
         try {
             $service = $this->blockServiceManager->get($block);
             $service->load($block);
+
+            if (null === $response) {
+                // In order to have the block's response's isCacheable() to true
+                $response = new Response();
+                $response->setTtl($block->getTtl());
+            }
+
             $newResponse = $service->execute($block, $response);
 
             if (!$newResponse instanceof Response) {

--- a/Twig/Extension/BlockExtension.php
+++ b/Twig/Extension/BlockExtension.php
@@ -182,7 +182,7 @@ class BlockExtension extends \Twig_Extension
         $response = $this->blockRenderer->render($block);
         $contextualKeys = $recorder ? $recorder->pop() : array();
         if ($response->isCacheable() && $cacheKeys && $cacheService) {
-            $cacheService->set($cacheKeys, $response, $block->getTtl(), $contextualKeys);
+            $cacheService->set($cacheKeys, $response, $response->getTtl(), $contextualKeys);
         }
 
         return $response->getContent();


### PR DESCRIPTION
This modification puts a TTL on a dynamically created block (with response = null), in order to allow it to be cached even though it's not persisted.
