### PR TITLE
Fix unit test service loader

### DIFF
--- a/Tests/Block/Loader/ServiceLoaderTest.php
+++ b/Tests/Block/Loader/ServiceLoaderTest.php
@@ -21,8 +21,8 @@ class ServiceLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testBlockNotFoundException()
     {
-        $loader = new ServiceLoader(array());
-        $loader->load('foo');
+        $loader = new ServiceLoader(array('type' => 'foo'));
+        $loader->load(array('type' => 'foo'));
     }
 
     public function testLoader()


### PR DESCRIPTION
In ServiceLoaderTest, the configuration array had no "type" key, which was throwing a PHPError instead of a RuntimeException, failing the unit test.
