### PR TITLE
Add possibility to define a 'ttl' block default setting

### DIFF
--- a/Block/BlockRenderer.php
+++ b/Block/BlockRenderer.php
@@ -73,6 +73,9 @@ class BlockRenderer implements BlockRendererInterface
 
             if (null === $response) {
                 // In order to have the block's response's isCacheable() to true
+                $defaultSettings = $service->getDefaultSettings();
+                $block->setSetting('ttl', isset($defaultSettings['ttl']) ? $defaultSettings['ttl'] : $block->getTtl());
+
                 $response = new Response();
                 $response->setTtl($block->getTtl());
             }

--- a/Model/BaseBlock.php
+++ b/Model/BaseBlock.php
@@ -258,17 +258,15 @@ abstract class BaseBlock implements BlockInterface
      */
     public function getTtl()
     {
-        if ($this->ttl === null) {
-            $ttl = $this->getSetting('ttl', 84600);
+        $ttl = $this->getSetting('ttl', 84600);
 
-            foreach ($this->getChildren() as $block) {
-                $blockTtl = $block->getTtl();
+        foreach ($this->getChildren() as $block) {
+            $blockTtl = $block->getTtl();
 
-                $ttl = ($blockTtl < $ttl) ? $blockTtl : $ttl;
-            }
-
-            $this->ttl = $ttl;
+            $ttl = ($blockTtl < $ttl) ? $blockTtl : $ttl;
         }
+
+        $this->ttl = $ttl;
 
         return $this->ttl;
     }


### PR DESCRIPTION
I've fixed block cache time (ttl) because actually all blocks had a `84600` default value cache time.

Moreover, the default value is not used until it's saved in block settings which requires users to click on save button on all blocks administration (and so, all pages where the block is present).

Thank you.
