### PR TITLE
NULL elements in block settings

### DIFF
--- a/Block/BlockContext.php
+++ b/Block/BlockContext.php
@@ -66,7 +66,7 @@ class BlockContext implements BlockContextInterface
     public function setSetting($name, $value)
     {
         if (!array_key_exists($name, $this->settings)) {
-            throw new \RuntimeException('It\'s not possible add non existing settings');
+            throw new \RuntimeException(sprintf('It\'s not possible add non existing setting `%s`.', $name));
         }
 
         $this->settings[$name] = $value;


### PR DESCRIPTION
Hey there,

I fixed a - in my opinion - wrong IF condition (BlockContext::getSetting()) which wasn't allowing NULL elements in block settings. While the BlockContext::setSetting() does care about NULL elements and I personally think its usefull to do so in the BlockContext::getSetting() too.

Cheers
