### PR TITLE
Fix exception after PR #70 in TeakCompilerPass

### DIFF
--- a/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -54,12 +54,12 @@ class TweakCompilerPass implements CompilerPassInterface
 
         foreach ($container->getParameter('sonata_block.blocks') as $service => $settings) {
             if (count($settings['settings']) > 0) {
-                $definition->addMethodCall('addBundleSettingsByType', array($service, $settings['settings'], true));
+                $definition->addMethodCall('addSettingsByType', array($service, $settings['settings'], true));
             }
         }
         foreach ($container->getParameter('sonata_block.blocks_by_class') as $class => $settings) {
             if (count($settings['settings']) > 0) {
-                $definition->addMethodCall('addBundleSettingsByClass', array($class, $settings['settings'], true));
+                $definition->addMethodCall('addSettingsByClass', array($class, $settings['settings'], true));
             }
         }
     }


### PR DESCRIPTION
FatalErrorException: Error: Call to undefined method Sonata\BlockBundle\Block\BlockContextManager::addBundleSettingsByType()
