### PR TITLE
fixed docblock tag (s/thrown/throws/)

### DIFF
--- a/Block/BlockContextManagerInterface.php
+++ b/Block/BlockContextManagerInterface.php
@@ -40,7 +40,7 @@ interface BlockContextManagerInterface
      *
      * @return BlockContextInterface
      *
-     * @thrown BlockOptionsException
+     * @throws BlockOptionsException
      */
     public function get($meta, array $settings = array());
 }


### PR DESCRIPTION
The incorrect name used here for the tag makes Doctrine's annotations parser report a semantical error if it tries to parse it.
