### PR TITLE
Renamed method of templating helper

### DIFF
--- a/Templating/Helper/BlockHelper.php
+++ b/Templating/Helper/BlockHelper.php
@@ -116,7 +116,7 @@ class BlockHelper extends Helper
      *
      * @return string
      */
-    public function renderBlock($block, array $options = array())
+    public function render($block, array $options = array())
     {
         $blockContext = $this->blockContextManager->get($block, $options);
 

--- a/Twig/Extension/BlockExtension.php
+++ b/Twig/Extension/BlockExtension.php
@@ -23,7 +23,7 @@ class BlockExtension extends BlockHelper implements \Twig_ExtensionInterface
     public function getFunctions()
     {
         return array(
-            'sonata_block_render'  => new \Twig_Function_Method($this, 'renderBlock', array('is_safe' => array('html'))),
+            'sonata_block_render'  => new \Twig_Function_Method($this, 'render', array('is_safe' => array('html'))),
             'sonata_block_include_javascripts'  => new \Twig_Function_Method($this, 'includeJavascripts', array('is_safe' => array('html'))),
             'sonata_block_include_stylesheets'  => new \Twig_Function_Method($this, 'includeStylesheets', array('is_safe' => array('html'))),
         );


### PR DESCRIPTION
I wanted to submit some changes to the CMF docs to add the new PHP templating helpers, and I discovered that it would be much nicer to use `render` instead of `renderBlock`.

Before

``` php
<?php echo $view['sonata_block']->renderBlock(...) ?>
```

After

``` php
<?php echo $view['sonata_block']->render(...) ?>
```

This'll also play nice with the CmfBlockBundle:

Before

``` php
<?php echo $view['blocks']->renderBlock(...) ?>
```

After

``` php
<?php echo $view['blocks']->render(...) ?>
```

I'm sorry I didn't discovered this when submiting the previous PR.
