### PR TITLE
#85 Fixed issue with usage of non existing class FormException

### DIFF
--- a/Form/Type/ServiceListType.php
+++ b/Form/Type/ServiceListType.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\BlockBundle\Form\Type;
 
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -64,11 +64,11 @@ class ServiceListType extends AbstractType
             'expanded'          => false,
             'choices'           => function (Options $options, $previousValue) use ($contexts, $manager) {
                 if (!isset($options['context'])) {
-                    throw new FormException('Please define a context option');
+                    throw new InvalidArgumentException('Please define a context option');
                 }
 
                 if (!isset($contexts[$options['context']])) {
-                    throw new FormException('Invalid context');
+                    throw new InvalidArgumentException('Invalid context');
                 }
 
                 $types = array();


### PR DESCRIPTION
Hi,

I made a merge for the issue I reported https://github.com/sonata-project/SonataBlockBundle/issues/85. Would be nice if it could be merged. 
