### PR TITLE
Remove dependency on KnpMenuBundle.

### DIFF
--- a/DependencyInjection/SonataBlockExtension.php
+++ b/DependencyInjection/SonataBlockExtension.php
@@ -73,6 +73,12 @@ class SonataBlockExtension extends Extension
      */
     public function configureMenus(ContainerBuilder $container, array $config)
     {
+        $bundles = $container->getParameter('kernel.bundles');
+        if (!isset($bundles['KnpMenuBundle'])) {
+            $container->removeDefinition('sonata.block.service.menu');
+            return;
+        }
+
         $container->getDefinition('sonata.block.service.menu')->replaceArgument(3, $config['menus']);
     }
 


### PR DESCRIPTION
Removes sonata.block.service.menu when there's no menus and KnpMenuBundle isn't active.
So KnpMenuBundle is now fully optional (see #108) 

This solution it's cleaner that I mentioned [here](https://github.com/sonata-project/SonataBlockBundle/pull/108#issuecomment-33505319)
