### PR TITLE
Removed public="false" from the service block example

### DIFF
--- a/Resources/doc/reference/your_first_block.rst
+++ b/Resources/doc/reference/your_first_block.rst
@@ -168,7 +168,7 @@ We are almost done! Now just declare the block as a service
 
 .. code-block:: xml
 
-    <service id="sonata.block.service.rss" class="Sonata\BlockBundle\Block\Service\RssBlockService" public="false">
+    <service id="sonata.block.service.rss" class="Sonata\BlockBundle\Block\Service\RssBlockService">
         <tag name="sonata.block" />
         <argument>sonata.block.service.rss</argument>
         <argument type="service" id="templating" />


### PR DESCRIPTION
Since this service must be public otherwise you can't use it when you would like to render it like this:

```
    $blockHelper = $this->get('sonata.block.templating.helper');
    $block = $blockHelper->render(array(
            'type'      => 'sonata.block.service.text',
            'settings'  => array(
                    'content'   => 'My content'
                )
        )
    );
```
