### PR TITLE
Removed public="false" on service sonata.block.templating.helper

### DIFF
--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -31,7 +31,7 @@
             <argument type="service" id="sonata.block.templating.helper" />
         </service>
 
-        <service id="sonata.block.templating.helper" class="Sonata\BlockBundle\Templating\Helper\BlockHelper" public="false">
+        <service id="sonata.block.templating.helper" class="Sonata\BlockBundle\Templating\Helper\BlockHelper">
             <tag name="templating.helper" alias="sonata_block" />
 
             <argument type="service" id="sonata.block.manager" />


### PR DESCRIPTION
Made sonata.block.templating.helper public so you can use it separately to render a block.

```
$blockHelper    = $this->get('sonata.block.templating.helper');

// Build the vacancy block
$vacancyBlockData = $this->getDoctrine()->getManager()->getRepository('AcmeBlockBundle:Block')->findOneByType('acme.block.service.vacancy');
$vacancyBlock = $blockHelper->render(array(
    'type'      => $vacancyBlockData->getType(),
    'settings'  => $vacancyBlockData->getSettings(),
));
```
