### PR TITLE
removed unnecessary code to generate block

### DIFF
--- a/Resources/doc/reference/events.rst
+++ b/Resources/doc/reference/events.rst
@@ -51,16 +51,6 @@ The event listener must return a ``BlockInterface`` so the rendering workflow wi
 
     class Discus
     {
-        protected $account;
-
-        /**
-         * @param string $account
-         */
-        public function __construct($account)
-        {
-            $this->account = $account;
-        }
-
         /**
          * @param  BlockEvent
          *


### PR DESCRIPTION
no `account` is passed to Discuss block when this is configured (xml or yaml)
