### PR TITLE
make the configuration dumpable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -210,4 +210,9 @@ class Configuration implements ConfigurationInterface
 
         return $treeBuilder;
     }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return new Configuration(array());
+    }
 }


### PR DESCRIPTION
Symfony does not know how to build the Configuration because it has a
Constructor. Tell it how to do it by implementing getConfiguration().
This makes the dump-reference work with this bundle.
