### PR TITLE
add phpunit as a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Resources/doc/_build
 composer.lock
 vendor
+bin

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,11 @@
     },
     "require-dev": {
         "knplabs/knp-menu-bundle": "~1.1",
-        "sonata-project/admin-bundle": "~2.2"
+        "sonata-project/admin-bundle": "~2.2",
+        "phpunit/phpunit": "~4.0"
+    },
+    "config": {
+        "bin-dir": "bin"
     },
     "suggest": {
         "knplabs/knp-menu-bundle": "~1.1",


### PR DESCRIPTION
It will get installed in bin.

Running the test suite is as simple as running this command :

```
bin/phpunit
```

As a bonus, you can get different phpunit version for different
projects.

see also : https://github.com/sebastianbergmann/phpunit/wiki/End-of-Life-for-PEAR-Installation-Method
