### PR TITLE
Changed default context

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -44,7 +44,7 @@ To use the ``BlockBundle``, add the following lines to your application configur
     # app/config/config.yml
 
     sonata_block:
-        default_contexts: [cms]
+        default_contexts: [sonata_page_bundle]
         blocks:
             sonata.admin.block.admin_list:
                 contexts:   [admin]


### PR DESCRIPTION
When I create a children block the link with the type of block is not made.
sonata_page_bundle as default_contexts correct the issue.
