### PR TITLE
[FIX] Configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -71,7 +71,6 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('enabled')->defaultValue('%kernel.debug%')->end()
                         ->scalarNode('template')->defaultValue('SonataBlockBundle:Profiler:block.html.twig')->end()
                         ->arrayNode('container_types')
-                            ->isRequired()
                             // add default value to well know users of BlockBundle
                             ->defaultValue(array('sonata.block.service.container', 'sonata.page.block.container', 'cmf.block.container', 'cmf.block.slideshow'))
                             ->prototype('scalar')->end()


### PR DESCRIPTION
InvalidConfigurationException: The child node "container_types" at path "sonata_block.profiler" must be configured.

Hello ! I guess the defaultValue() was added after isRequired() and so don't need to be maintained
