### PR TITLE
id can be a string e.g. in case of cmf

### DIFF
--- a/Block/BlockContextManager.php
+++ b/Block/BlockContextManager.php
@@ -109,7 +109,7 @@ class BlockContextManager implements BlockContextManagerInterface
         } catch (ExceptionInterface $e) {
             if ($this->logger) {
                 $this->logger->error(sprintf(
-                    '[cms::blockContext] block.id=%d - error while resolving options - %s',
+                    '[cms::blockContext] block.id=%s - error while resolving options - %s',
                     $block->getId(),
                     $e->getMessage()
                 ));


### PR DESCRIPTION
exceptions in cmf blocks lead currently to ERROR - [cms::blockContext] block.id=0 - error while resolving options - ...

with this change you see the correct block id
