### PR TITLE
Updated template to use KnpMenu Matcher

### DIFF
--- a/Resources/views/Block/block_side_menu_template.html.twig
+++ b/Resources/views/Block/block_side_menu_template.html.twig
@@ -25,9 +25,9 @@ file that was distributed with this source code.
     {% if item.displayed %}
         {# building the class of the item #}
         {%- set classes = item.attribute('class') is not empty ? [item.attribute('class')] : [] %}
-        {%- if item.current %}
+        {%- if matcher.isCurrent(item) %}
             {%- set classes = classes|merge([options.currentClass]) %}
-        {%- elseif item.currentAncestor %}
+        {%- elseif matcher.isAncestor(item, options.matchingDepth) %}
             {%- set classes = classes|merge([options.ancestorClass]) %}
         {%- endif %}
         {%- if item.actsLikeFirst %}


### PR DESCRIPTION
Fixes issue #174

Here is the commit where KnpMenu removed the methods from MenuItem
https://github.com/KnpLabs/KnpMenu/commit/e7ef14a9469545423276e8516196496664429b81

Here is the commit where they added Matcher
https://github.com/KnpLabs/KnpMenu/commit/a90d389e9d3d76d37abcbf2634f8ce62cd5e1e49