### PR TITLE
fixed broken knp-menu call

### DIFF
--- a/Resources/views/Block/block_side_menu_template.html.twig
+++ b/Resources/views/Block/block_side_menu_template.html.twig
@@ -25,9 +25,9 @@ file that was distributed with this source code.
     {% if item.displayed %}
         {# building the class of the item #}
         {%- set classes = item.attribute('class') is not empty ? [item.attribute('class')] : [] %}
-        {%- if item.current %}
+        {%- if matcher.isCurrent(item) %}
             {%- set classes = classes|merge([options.currentClass]) %}
-        {%- elseif item.currentAncestor %}
+        {%- elseif matcher.isAncestor(item, options.depth) %}
             {%- set classes = classes|merge([options.ancestorClass]) %}
         {%- endif %}
         {%- if item.actsLikeFirst %}


### PR DESCRIPTION
The `side-menu` code seems to be incompatible with [`knp 2.x`](https://github.com/sonata-project/SonataBlockBundle/blob/master/composer.json#L27). This patch fixes it. Disclaimer: Taken from [stackoverflow](http://stackoverflow.com/a/25848817/965338).

Refs #174