### PR TITLE
Fix deprecated namespace of FlattenException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ A [BC BREAK] means the update will break the project for many reasons:
 * new dependencies
 * class refactoring
 
+### 2015-05-05
+
+* Symfony 2.2 is not supported anymore.
+
 ### 2014-04-23
 
 * [BC BREAK] Complete support for context, add new method in BlockServiceManager (getServicesByContext)

--- a/Exception/Renderer/InlineDebugRenderer.php
+++ b/Exception/Renderer/InlineDebugRenderer.php
@@ -10,11 +10,10 @@
 
 namespace Sonata\BlockBundle\Exception\Renderer;
 
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Templating\EngineInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-
-use Symfony\Component\HttpKernel\Exception\FlattenException;
 
 /**
  * This renderer uses a template to display an error message at the block position with extensive debug information.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "symfony/http-kernel": "~2.2",
+        "symfony/http-kernel": "~2.3",
         "symfony/form": "~2.2",
         "doctrine/common": "~2.3",
         "sonata-project/core-bundle": "~2.3,>=2.3.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "symfony/http-kernel": "~2.3",
-        "symfony/form": "~2.2",
+        "symfony/form": "~2.3",
         "doctrine/common": "~2.3",
         "sonata-project/core-bundle": "~2.3,>=2.3.1",
         "sonata-project/cache": "~1.0"


### PR DESCRIPTION
Fix deprecated:

> The Symfony\Component\HttpKernel\Exception\FlattenException class is deprecated since version 2.3 and will be removed in 3.0. Use the Symfony\Component\Debug\Exception\FlattenException class instead.