### PR TITLE
Fix deprecated Event::getName usage

### DIFF
--- a/Templating/Helper/BlockHelper.php
+++ b/Templating/Helper/BlockHelper.php
@@ -249,7 +249,7 @@ class BlockHelper extends Helper
                 'template_code' => $name,
                 'event_name'    => $eventName,
                 'blocks'        => $this->getEventBlocks($event),
-                'listeners'     => $this->getEventListeners($event),
+                'listeners'     => $this->getEventListeners($eventName),
             );
         }
 
@@ -273,15 +273,15 @@ class BlockHelper extends Helper
     }
 
     /**
-     * @param BlockEvent $event
+     * @param string $eventName
      *
      * @return array
      */
-    protected function getEventListeners(BlockEvent $event)
+    protected function getEventListeners($eventName)
     {
         $results = array();
 
-        foreach ($this->eventDispatcher->getListeners($event->getName()) as $listener) {
+        foreach ($this->eventDispatcher->getListeners($eventName) as $listener) {
             if (is_object($listener[0])) {
                 $results[] = get_class($listener[0]);
             } else if (is_string($listener[0])) {


### PR DESCRIPTION
Fixes deprecated:

> The Symfony\Component\EventDispatcher\Event::getName method is deprecated since version 2.4 and will be removed in 3.0. The event name can be received in the listener call instead.