### PR TITLE
[WIP] Add configureSettings to block service

### DIFF
--- a/Block/AbstractBlockService.php
+++ b/Block/AbstractBlockService.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Block;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * Class AbstractBlockService
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+abstract class AbstractBlockService implements BlockServiceInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    {
+        $this->configureSettings($resolver);
+    }
+
+    /**
+     * Define the default options for the block
+     *
+     * @param OptionsResolver $resolver
+     */
+    public function configureSettings(OptionsResolver $resolver)
+    {
+    }
+}

--- a/Block/BlockContextManager.php
+++ b/Block/BlockContextManager.php
@@ -19,6 +19,9 @@ use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
+/**
+ * Class BlockContextManager
+ */
 class BlockContextManager implements BlockContextManagerInterface
 {
     protected $blockLoader;

--- a/Block/BlockContextManagerInterface.php
+++ b/Block/BlockContextManagerInterface.php
@@ -12,8 +12,10 @@
 namespace Sonata\BlockBundle\Block;
 
 use Sonata\BlockBundle\Exception\BlockOptionsException;
-use Sonata\BlockBundle\Model\BlockInterface;
 
+/**
+ * Interface BlockContextManagerInterface
+ */
 interface BlockContextManagerInterface
 {
     const CACHE_KEY = 'context';

--- a/Block/BlockServiceInterface.php
+++ b/Block/BlockServiceInterface.php
@@ -11,13 +11,14 @@
 
 namespace Sonata\BlockBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Validator\ErrorElement;
 
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
+/**
+ * Interface BlockServiceInterface
+ */
 interface BlockServiceInterface
 {
     /**
@@ -37,6 +38,10 @@ interface BlockServiceInterface
      * Define the default options for the block
      *
      * @param OptionsResolverInterface $resolver
+     *
+     * @deprecated since version 2.3, to be renamed in 3.0.
+     *             Use the method configureSettings instead.
+     *             This method will be added to the BlockServiceInterface with SonataBlockBundle 3.0.
      */
     public function setDefaultSettings(OptionsResolverInterface $resolver);
 

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -1,0 +1,40 @@
+UPGRADE FROM 2.2 to 2.3
+=======================
+
+## Deprecated BlockServiceInterface::setDefaultSettings
+
+`BlockServiceInterface::setDefaultSettings` method is now deprecated.
+
+A new `AbstractBlockService` implementing `BlockServiceInterface` was also introduced to prevent BC.
+
+A BlockService should now extends `AbstractBlockService` and use `configureSettings` method.
+
+Before:
+
+```php
+use Sonata\BlockBundle\Block\BlockServiceInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class TextBlockService implements BlockServiceInterface
+{
+    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    {
+        // ...
+    }
+}
+```
+
+After:
+
+```php
+use Sonata\BlockBundle\Block\AbstractBlockService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TextBlockService extends AbstractBlockService
+{
+    public function configureSettings(OptionsResolver $resolver)
+    {
+        // ...
+    }
+}
+```


### PR DESCRIPTION
`AbstractBlockService::configureSettings` fixes Symfony deprecation issue.
`BlockServiceInterface::setDefaultSettings` is now deprecated.

Fixes #201