### PR TITLE
Add configureSettings to block service

### DIFF
--- a/Block/AbstractBlockService.php
+++ b/Block/AbstractBlockService.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Block;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * Class AbstractBlockService
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+abstract class AbstractBlockService implements BlockServiceInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    {
+        $this->configureSettings($resolver);
+    }
+
+    /**
+     * Define the default options for the block
+     *
+     * @param OptionsResolver $resolver
+     */
+    public function configureSettings(OptionsResolver $resolver)
+    {
+    }
+}

--- a/Block/BaseBlockService.php
+++ b/Block/BaseBlockService.php
@@ -25,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  *
  * @author     Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-abstract class BaseBlockService implements BlockServiceInterface, BlockAdminServiceInterface
+abstract class BaseBlockService extends AbstractBlockService implements BlockAdminServiceInterface
 {
     protected $name;
 
@@ -171,14 +171,6 @@ abstract class BaseBlockService implements BlockServiceInterface, BlockAdminServ
     public function getStylesheets($media)
     {
         return array();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
-    {
-
     }
 
     /**

--- a/Block/BlockContextManager.php
+++ b/Block/BlockContextManager.php
@@ -19,6 +19,9 @@ use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
+/**
+ * Class BlockContextManager
+ */
 class BlockContextManager implements BlockContextManagerInterface
 {
     protected $blockLoader;
@@ -37,6 +40,14 @@ class BlockContextManager implements BlockContextManagerInterface
     protected $logger;
 
     /**
+     * Used for deprecation check on {@link resolve} method.
+     * To be removed in 3.0 with BC system.
+     *
+     * @var array
+     */
+    private $reflectionCache;
+
+    /**
      * @param BlockLoaderInterface         $blockLoader
      * @param BlockServiceManagerInterface $blockService
      * @param array                        $cacheBlocks
@@ -45,10 +56,11 @@ class BlockContextManager implements BlockContextManagerInterface
     public function __construct(BlockLoaderInterface $blockLoader, BlockServiceManagerInterface $blockService,
         array $cacheBlocks = array(), LoggerInterface $logger = null
     ) {
-        $this->blockLoader  = $blockLoader;
-        $this->blockService = $blockService;
-        $this->cacheBlocks  = $cacheBlocks;
-        $this->logger       = $logger;
+        $this->blockLoader     = $blockLoader;
+        $this->blockService    = $blockService;
+        $this->cacheBlocks     = $cacheBlocks;
+        $this->logger          = $logger;
+        $this->reflectionCache = array();
     }
 
     /**
@@ -97,16 +109,9 @@ class BlockContextManager implements BlockContextManagerInterface
             return false;
         }
 
-        $optionsResolver = new OptionsResolver();
-
-        $this->setDefaultSettings($optionsResolver, $block);
-
-        $service = $this->blockService->get($block);
-        $service->setDefaultSettings($optionsResolver, $block);
-
         $originalSettings = $settings;
         try {
-            $settings = $optionsResolver->resolve(array_merge($block->getSettings(), $settings));
+            $settings = $this->resolve($block, array_merge($block->getSettings(), $settings));
         } catch (ExceptionInterface $e) {
             if ($this->logger) {
                 $this->logger->error(sprintf(
@@ -116,14 +121,7 @@ class BlockContextManager implements BlockContextManagerInterface
                 ));
             }
 
-            $optionsResolver = new OptionsResolver();
-
-            $this->setDefaultSettings($optionsResolver, $block);
-
-            $service = $this->blockService->get($block);
-            $service->setDefaultSettings($optionsResolver, $block);
-
-            $settings = $optionsResolver->resolve($settings);
+            $settings = $this->resolve($block, $settings);
         }
 
         $blockContext = new BlockContext($block, $settings);
@@ -136,8 +134,17 @@ class BlockContextManager implements BlockContextManagerInterface
     /**
      * @param OptionsResolverInterface $optionsResolver
      * @param BlockInterface           $block
+     *
+     * @deprecated since version 2.3, to be renamed in 3.0.
+     *             Use the method configureSettings instead.
      */
     protected function setDefaultSettings(OptionsResolverInterface $optionsResolver, BlockInterface $block)
+    {
+        trigger_error(__CLASS__.'::'.__METHOD__.' is deprecated since version 2.3, to be renamed in 3.0. Use '.__CLASS__.'::configureSettings instead.');
+        $this->configureSettings($optionsResolver, $block);
+    }
+
+    protected function configureSettings(OptionsResolver $optionsResolver, BlockInterface $block)
     {
         // defaults for all blocks
         $optionsResolver->setDefaults(array(
@@ -213,5 +220,41 @@ class BlockContextManager implements BlockContextManagerInterface
             $extraCacheKeys[self::CACHE_KEY] = $settings;
             $blockContext->setSetting('extra_cache_keys', $extraCacheKeys);
         }
+    }
+
+    private function resolve(BlockInterface $block, $settings)
+    {
+        $optionsResolver = new OptionsResolver();
+
+        $this->configureSettings($optionsResolver, $block);
+
+        $service = $this->blockService->get($block);
+        $service->setDefaultSettings($optionsResolver, $block);
+
+        // Caching method reflection
+        $serviceClass = get_class($service);
+        if (!isset($this->reflectionCache[$serviceClass])) {
+            $reflector = new \ReflectionMethod($service, 'setDefaultSettings');
+            $isOldOverwritten = $reflector->getDeclaringClass()->getName() !== 'Sonata\BlockBundle\Block\AbstractBlockService';
+
+            // Prevention for service classes implementing directly the interface and not extends the new base class
+            if (!method_exists($service, 'configureSettings')) {
+                $isNewOverwritten = false;
+            } else {
+                $reflector = new \ReflectionMethod($service, 'configureSettings');
+                $isNewOverwritten = $reflector->getDeclaringClass()->getName() !== 'Sonata\BlockBundle\Block\AbstractBlockService';
+            }
+
+            $this->reflectionCache[$serviceClass] = array(
+                'isOldOverwritten' => $isOldOverwritten,
+                'isNewOverwritten' => $isNewOverwritten,
+            );
+        }
+
+        if ($this->reflectionCache[$serviceClass]['isOldOverwritten'] && !$this->reflectionCache[$serviceClass]['isNewOverwritten']) {
+            trigger_error('The Sonata\BlockBundle\Block\BlockServiceInterface::setDefaultSettings() method is deprecated since version 2.3 and will be removed in 3.0. Use configureSettings() instead. This method will be added to the BlockServiceInterface with SonataBlockBundle 3.0.', E_USER_DEPRECATED);
+        }
+
+        return $optionsResolver->resolve($settings);
     }
 }

--- a/Block/BlockContextManagerInterface.php
+++ b/Block/BlockContextManagerInterface.php
@@ -12,8 +12,10 @@
 namespace Sonata\BlockBundle\Block;
 
 use Sonata\BlockBundle\Exception\BlockOptionsException;
-use Sonata\BlockBundle\Model\BlockInterface;
 
+/**
+ * Interface BlockContextManagerInterface
+ */
 interface BlockContextManagerInterface
 {
     const CACHE_KEY = 'context';

--- a/Block/BlockServiceInterface.php
+++ b/Block/BlockServiceInterface.php
@@ -11,13 +11,14 @@
 
 namespace Sonata\BlockBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Validator\ErrorElement;
 
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
+/**
+ * Interface BlockServiceInterface
+ */
 interface BlockServiceInterface
 {
     /**
@@ -37,6 +38,10 @@ interface BlockServiceInterface
      * Define the default options for the block
      *
      * @param OptionsResolverInterface $resolver
+     *
+     * @deprecated since version 2.3, to be renamed in 3.0.
+     *             Use the method configureSettings instead.
+     *             This method will be added to the BlockServiceInterface with SonataBlockBundle 3.0.
      */
     public function setDefaultSettings(OptionsResolverInterface $resolver);
 

--- a/Block/Service/ContainerBlockService.php
+++ b/Block/Service/ContainerBlockService.php
@@ -18,7 +18,7 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Render children pages
@@ -74,7 +74,7 @@ class ContainerBlockService extends BaseBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'code'        => '',

--- a/Block/Service/MenuBlockService.php
+++ b/Block/Service/MenuBlockService.php
@@ -20,7 +20,7 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class MenuBlockService
@@ -102,7 +102,7 @@ class MenuBlockService extends BaseBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'title'          => $this->getName(),

--- a/Block/Service/RssBlockService.php
+++ b/Block/Service/RssBlockService.php
@@ -12,7 +12,7 @@
 namespace Sonata\BlockBundle\Block\Service;
 
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\CoreBundle\Validator\ErrorElement;
@@ -38,7 +38,7 @@ class RssBlockService extends BaseBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'url'      => false,

--- a/Block/Service/TemplateBlockService.php
+++ b/Block/Service/TemplateBlockService.php
@@ -18,7 +18,7 @@ use Sonata\AdminBundle\Form\FormMapper;
 
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Block\BaseBlockService;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author     Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -59,7 +59,7 @@ class TemplateBlockService extends BaseBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'template' => 'SonataBlockBundle:Block:block_template.html.twig'

--- a/Block/Service/TextBlockService.php
+++ b/Block/Service/TextBlockService.php
@@ -19,7 +19,7 @@ use Sonata\CoreBundle\Validator\ErrorElement;
 
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Block\BaseBlockService;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  *
@@ -69,7 +69,7 @@ class TextBlockService extends BaseBlockService
     /**
      * {@inheritdoc}
      */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'content'  => 'Insert your custom content here',

--- a/Tests/Block/BlockContextManagerTest.php
+++ b/Tests/Block/BlockContextManagerTest.php
@@ -18,7 +18,7 @@ class BlockContextManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetWithValidData()
     {
-        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $service = $this->getMock('Sonata\BlockBundle\Block\AbstractBlockService');
         $service->expects($this->once())->method('setDefaultSettings');
 
         $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
@@ -46,7 +46,7 @@ class BlockContextManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetWithSettings()
     {
-        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $service = $this->getMock('Sonata\BlockBundle\Block\AbstractBlockService');
         $service->expects($this->once())->method('setDefaultSettings');
 
         $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
@@ -87,7 +87,7 @@ class BlockContextManagerTest extends \PHPUnit_Framework_TestCase
         $logger = $this->getMock('Psr\Log\LoggerInterface');
         $logger->expects($this->exactly(1))->method('error');
 
-        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $service = $this->getMock('Sonata\BlockBundle\Block\AbstractBlockService');
         $service->expects($this->exactly(2))->method('setDefaultSettings');
 
         $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -1,0 +1,40 @@
+UPGRADE FROM 2.2 to 2.3
+=======================
+
+## Deprecated BlockServiceInterface::setDefaultSettings
+
+`BlockServiceInterface::setDefaultSettings` method is now deprecated.
+
+A new `AbstractBlockService` implementing `BlockServiceInterface` was also introduced to prevent BC.
+
+A BlockService should now extends `AbstractBlockService` and use `configureSettings` method.
+
+Before:
+
+```php
+use Sonata\BlockBundle\Block\BlockServiceInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class TextBlockService implements BlockServiceInterface
+{
+    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    {
+        // ...
+    }
+}
+```
+
+After:
+
+```php
+use Sonata\BlockBundle\Block\AbstractBlockService;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TextBlockService extends AbstractBlockService
+{
+    public function configureSettings(OptionsResolver $resolver)
+    {
+        // ...
+    }
+}
+```


### PR DESCRIPTION
`AbstractBlockService::configureSettings` fixes Symfony deprecation issue.
`BlockServiceInterface::setDefaultSettings` is now deprecated.

Fixes #201

@rande Please don't merge it now! :-)