### PR TITLE
Silenced trigger_error

### DIFF
--- a/Block/BlockContextManager.php
+++ b/Block/BlockContextManager.php
@@ -140,7 +140,7 @@ class BlockContextManager implements BlockContextManagerInterface
     protected function setDefaultSettings(OptionsResolverInterface $optionsResolver, BlockInterface $block)
     {
         if (get_called_class() !== __CLASS__) {
-            trigger_error('The '.__METHOD__.' is deprecated since version 2.3, to be renamed in 3.0. Use '.__CLASS__.'::configureSettings instead.', E_USER_DEPRECATED);
+            @trigger_error('The '.__METHOD__.' is deprecated since version 2.3, to be renamed in 3.0. Use '.__CLASS__.'::configureSettings instead.', E_USER_DEPRECATED);
         }
         $this->configureSettings($optionsResolver, $block);
     }
@@ -253,7 +253,7 @@ class BlockContextManager implements BlockContextManagerInterface
         }
 
         if ($this->reflectionCache[$serviceClass]['isOldOverwritten'] && !$this->reflectionCache[$serviceClass]['isNewOverwritten']) {
-            trigger_error('The Sonata\BlockBundle\Block\BlockServiceInterface::setDefaultSettings() method is deprecated since version 2.3 and will be removed in 3.0. Use configureSettings() instead. This method will be added to the BlockServiceInterface with SonataBlockBundle 3.0.', E_USER_DEPRECATED);
+            @trigger_error('The Sonata\BlockBundle\Block\BlockServiceInterface::setDefaultSettings() method is deprecated since version 2.3 and will be removed in 3.0. Use configureSettings() instead. This method will be added to the BlockServiceInterface with SonataBlockBundle 3.0.', E_USER_DEPRECATED);
         }
 
         return $optionsResolver->resolve($settings);


### PR DESCRIPTION
Regarding Symfony recommendation, `trigger_error` for deprecation must be silenced.

This will also resolve these kind of error: https://travis-ci.org/sonata-project/SonataPageBundle/jobs/72899353#L392

TODO: Make a new patch release after that.