### PR TITLE
added missing type check in BH::stopTracing()

### DIFF
--- a/Templating/Helper/BlockHelper.php
+++ b/Templating/Helper/BlockHelper.php
@@ -213,6 +213,10 @@ class BlockHelper extends Helper
      */
     protected function stopTracing(BlockInterface $block, array $stats)
     {
+        if (is_array($this->traces[$block->getId()])) {
+            return;
+        }
+        
         $e = $this->traces[$block->getId()]->stop();
 
         $this->traces[$block->getId()] = array_merge($stats, array(


### PR DESCRIPTION
In some rare cases (found this while testing recursive references in cmf reference block) stopTracing() is called on element, whose stopwatch was already stopped before. This type check fixes it.
See https://github.com/sonata-project/SonataBlockBundle/issues/233