### PR TITLE
Use FakeTemplating in BlockService tests

### DIFF
--- a/Tests/Block/AbstractBlockServiceTest.php
+++ b/Tests/Block/AbstractBlockServiceTest.php
@@ -7,7 +7,7 @@ use Sonata\BlockBundle\Block\BlockContextManager;
 use Sonata\BlockBundle\Block\BlockContextManagerInterface;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -33,14 +33,14 @@ abstract class AbstractBlockServiceTest extends \PHPUnit_Framework_TestCase
     private $blockContextManager;
 
     /**
-     * @var EngineInterface
+     * @var FakeTemplating
      */
     protected $templating;
 
     protected function setUp()
     {
         $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $this->templating = new FakeTemplating();
 
         $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
         $this->blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');


### PR DESCRIPTION
This would be more helpfull when testing blocks.

You could reuse ``templating`` when testing the execute method https://github.com/sonata-project/SonataDashboardBundle/blob/master/Tests/Block/ContainerBlockServiceTest.php#L48-L51