### PR TITLE
Implemented a "sonata_block_exists" twig function

### DIFF
--- a/Block/BlockContextManager.php
+++ b/Block/BlockContextManager.php
@@ -104,6 +104,18 @@ class BlockContextManager implements BlockContextManagerInterface
     }
 
     /**
+     * Check if a given block type exists.
+     *
+     * @param string $type Block type to check for
+     *
+     * @return bool
+     */
+    public function exists($type)
+    {
+        return $this->blockLoader->exists($type);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function get($meta, array $settings = array())

--- a/Block/BlockLoaderChain.php
+++ b/Block/BlockLoaderChain.php
@@ -29,6 +29,24 @@ class BlockLoaderChain implements BlockLoaderInterface
     }
 
     /**
+     * Check if a given block type exists.
+     *
+     * @param string $type Block type to check for
+     *
+     * @return bool
+     */
+    public function exists($type)
+    {
+        foreach ($this->loaders as $loader) {
+            if ($loader->exists($type)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function load($block)

--- a/Block/Loader/ServiceLoader.php
+++ b/Block/Loader/ServiceLoader.php
@@ -30,6 +30,18 @@ class ServiceLoader implements BlockLoaderInterface
     }
 
     /**
+     * Check if a given block type exists.
+     *
+     * @param string $type Block type to check for
+     *
+     * @return bool
+     */
+    public function exists($type)
+    {
+        return in_array($type, $this->types, true);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function load($configuration)

--- a/Templating/Helper/BlockHelper.php
+++ b/Templating/Helper/BlockHelper.php
@@ -323,6 +323,18 @@ class BlockHelper extends Helper
     }
 
     /**
+     * Check if a given block type exists.
+     *
+     * @param string $type Block type to check for
+     *
+     * @return bool
+     */
+    public function exists($type)
+    {
+        return $this->blockContextManager->exists($type);
+    }
+
+    /**
      * @param mixed $block
      * @param array $options
      *

--- a/Twig/Extension/BlockExtension.php
+++ b/Twig/Extension/BlockExtension.php
@@ -36,6 +36,9 @@ class BlockExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
+            new \Twig_SimpleFunction('sonata_block_exists',
+                array($this->blockHelper, 'exists')
+            ),
             new \Twig_SimpleFunction('sonata_block_render',
                 array($this->blockHelper, 'render'),
                 array('is_safe' => array('html'))


### PR DESCRIPTION
This adds a "sonata_block_exists" twig function that checks if a given block type exists.

I also added "exists" methods to ``BlockHelper``, ``BlockHelperInterface``, ``BlockContextManager`` and ``BlockContextManagerInterface`` as well as ``BlockLoaderChain``, ``ServiceLoader`` and ``BlockLoaderInterface``. The latter 3 however already have a method called "support" which from the name sounds like it should do something similar, but it seems to always just return true. I didn't find out what that "support" method is really used for, so any help in understanding what it does is appreciated.

It is needed for https://github.com/sonata-project/SonataAdminBundle/pull/3469, but should be useful for other use cases as well.