### PR TITLE
Changed the log level on exceptions in BlockRenderer from critical to…

### DIFF
--- a/Block/BlockRenderer.php
+++ b/Block/BlockRenderer.php
@@ -93,7 +93,11 @@ class BlockRenderer implements BlockRendererInterface
             $response = $this->addMetaInformation($response, $blockContext, $service);
         } catch (\Exception $exception) {
             if ($this->logger) {
-                $this->logger->critical(sprintf('[cms::renderBlock] block.id=%d - error while rendering block - %s', $block->getId(), $exception->getMessage()));
+                $this->logger->error(sprintf(
+                    '[cms::renderBlock] block.id=%d - error while rendering block - %s',
+                    $block->getId(),
+                    $exception->getMessage()
+                ), compact('exception'));
             }
 
             // reseting the state object

--- a/Tests/Block/BlockRendererTest.php
+++ b/Tests/Block/BlockRendererTest.php
@@ -104,7 +104,7 @@ class BlockRendererTest extends \PHPUnit_Framework_TestCase
             }));
 
         // mock the logger to ensure a crit message is logged
-        $this->logger->expects($this->once())->method('critical');
+        $this->logger->expects($this->once())->method('error');
 
         // mock a block object
         $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
@@ -145,7 +145,7 @@ class BlockRendererTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($response));
 
         // mock the logger to ensure a crit message is logged
-        $this->logger->expects($this->once())->method('critical');
+        $this->logger->expects($this->once())->method('error');
 
         // mock a block object
         $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- The log level on exceptions in `BlockRenderer` is decreased from critical to error.
```

### Subject

As critical, log entries may trigger further actions, i.e. sending mails from monolog and similar. This makes even more sense as the default settings in the block bundle simply catch the exception.
