### PR TITLE
Removed asterisk from profiler toolbar

### DIFF
--- a/Resources/views/Profiler/block.html.twig
+++ b/Resources/views/Profiler/block.html.twig
@@ -9,7 +9,6 @@
                 <a href="{{ path('_profiler', { 'token': token, 'panel': name }) }}">
                     {# fake image span #}<span style="width:0px; height: 28px; vertical-align: middle;"></span>
                     <span class="sf-toolbar-status">{{ collector.getTotalBlock() }}</span> blocks
-                    {% if collector.events|length > 0 %}<strong>*</strong>{% endif %}
                 </a>
             </div>
         {% else %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of https://github.com/sonata-project/SonataBlockBundle/pull/230

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Removed
- Removed the asterisk sign from the profiler toolbar, because it's no symfony standard. No other profiler component is using a sign.
```

### Subject
Removed the asterisk sign from the profiler toolbar, because it's no symfony standard. No other profiler component is using a sign.