### PR TITLE
Always use service id as block id

### DIFF
--- a/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -34,18 +34,8 @@ class TweakCompilerPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('sonata.block') as $id => $tags) {
             $definition = $container->getDefinition($id);
 
-            $arguments = $definition->getArguments();
-
             // Replace empty block id with service id
-            if (strlen($arguments[0]) == 0) {
-                $definition->replaceArgument(0, $id);
-            } elseif ($id != $arguments[0]) {
-                // NEXT_MAJOR: Remove deprecation notice
-                @trigger_error(
-                    'Using different service id and block id is deprecated since 3.x and will be removed in 4.0.',
-                    E_USER_DEPRECATED
-                );
-            }
+            $definition->replaceArgument(0, $id);
 
             $manager->addMethodCall('add', array($id, $id, isset($parameters[$id]) ? $parameters[$id]['contexts'] : array()));
         }

--- a/Resources/config/block.xml
+++ b/Resources/config/block.xml
@@ -11,34 +11,34 @@
     <services>
         <service id="sonata.block.service.container" class="%sonata.block.service.container.class%">
             <tag name="sonata.block"/>
-            <argument>sonata.block.container</argument>
+            <argument/>
             <argument type="service" id="templating"/>
         </service>
         <service id="sonata.block.service.empty" class="%sonata.block.service.empty.class%">
             <tag name="sonata.block"/>
-            <argument>sonata.block.empty</argument>
+            <argument/>
             <argument type="service" id="templating"/>
         </service>
         <service id="sonata.block.service.text" class="%sonata.block.service.text.class%">
             <tag name="sonata.block"/>
-            <argument>sonata.block.text</argument>
+            <argument/>
             <argument type="service" id="templating"/>
         </service>
         <service id="sonata.block.service.rss" class="%sonata.block.service.rss.class%">
             <tag name="sonata.block"/>
-            <argument>sonata.block.rss</argument>
+            <argument/>
             <argument type="service" id="templating"/>
         </service>
         <service id="sonata.block.service.menu" class="%sonata.block.service.menu.class%">
             <tag name="sonata.block"/>
-            <argument>sonata.block.menu</argument>
+            <argument/>
             <argument type="service" id="templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="collection"/>
         </service>
         <service id="sonata.block.service.template" class="%sonata.block.service.template.class%">
             <tag name="sonata.block"/>
-            <argument>sonata.block.template</argument>
+            <argument/>
             <argument type="service" id="templating"/>
         </service>
     </services>

--- a/Resources/translations/SonataBlockBundle.de.xliff
+++ b/Resources/translations/SonataBlockBundle.de.xliff
@@ -2,24 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="SonataBlockBundle.en.xliff">
         <body>
-            <trans-unit id="sonata.block.container">
-                <source>sonata.block.container</source>
+            <trans-unit id="sonata.block.service.container">
+                <source>sonata.block.service.container</source>
                 <target>Container</target>
             </trans-unit>
-            <trans-unit id="sonata.block.text">
-                <source>sonata.block.text</source>
+            <trans-unit id="sonata.block.service.text">
+                <source>sonata.block.service.text</source>
                 <target>Einfacher Text</target>
             </trans-unit>
-            <trans-unit id="sonata.block.rss">
-                <source>sonata.block.rss</source>
+            <trans-unit id="sonata.block.service.rss">
+                <source>sonata.block.service.rss</source>
                 <target>RSS Feed</target>
             </trans-unit>
-            <trans-unit id="sonata.block.menu">
-                <source>sonata.block.menu</source>
+            <trans-unit id="sonata.block.service.menu">
+                <source>sonata.block.service.menu</source>
                 <target>Menü</target>
             </trans-unit>
-            <trans-unit id="sonata.block.template">
-                <source>sonata.block.template</source>
+            <trans-unit id="sonata.block.service.template">
+                <source>sonata.block.service.template</source>
                 <target>Template</target>
             </trans-unit>
         </body>

--- a/Resources/translations/SonataBlockBundle.en.xliff
+++ b/Resources/translations/SonataBlockBundle.en.xliff
@@ -2,24 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
-            <trans-unit id="sonata.block.container">
-                <source>sonata.block.container</source>
+            <trans-unit id="sonata.block.service.container">
+                <source>sonata.block.service.container</source>
                 <target>Container</target>
             </trans-unit>
-            <trans-unit id="sonata.block.text">
-                <source>sonata.block.text</source>
+            <trans-unit id="sonata.block.service.text">
+                <source>sonata.block.service.text</source>
                 <target>Simple text</target>
             </trans-unit>
-            <trans-unit id="sonata.block.rss">
-                <source>sonata.block.rss</source>
+            <trans-unit id="sonata.block.service.rss">
+                <source>sonata.block.service.rss</source>
                 <target>RSS feed</target>
             </trans-unit>
-            <trans-unit id="sonata.block.menu">
-                <source>sonata.block.menu</source>
+            <trans-unit id="sonata.block.service.menu">
+                <source>sonata.block.service.menu</source>
                 <target>Menu</target>
             </trans-unit>
-            <trans-unit id="sonata.block.template">
-                <source>sonata.block.template</source>
+            <trans-unit id="sonata.block.service.template">
+                <source>sonata.block.service.template</source>
                 <target>Template</target>
             </trans-unit>
         </body>

--- a/Resources/translations/SonataBlockBundle.fr.xliff
+++ b/Resources/translations/SonataBlockBundle.fr.xliff
@@ -2,24 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="fr" datatype="plaintext" original="SonataBlockBundle.en.xliff">
         <body>
-            <trans-unit id="sonata.block.container">
-                <source>sonata.block.container</source>
+            <trans-unit id="sonata.block.service.container">
+                <source>sonata.block.service.container</source>
                 <target>Conteneur</target>
             </trans-unit>
-            <trans-unit id="sonata.block.text">
-                <source>sonata.block.text</source>
+            <trans-unit id="sonata.block.service.text">
+                <source>sonata.block.service.text</source>
                 <target>Texte</target>
             </trans-unit>
-            <trans-unit id="sonata.block.rss">
-                <source>sonata.block.rss</source>
+            <trans-unit id="sonata.block.service.rss">
+                <source>sonata.block.service.rss</source>
                 <target>Flux RSS</target>
             </trans-unit>
-            <trans-unit id="sonata.block.menu">
-                <source>sonata.block.menu</source>
+            <trans-unit id="sonata.block.service.menu">
+                <source>sonata.block.service.menu</source>
                 <target>Menu</target>
             </trans-unit>
-            <trans-unit id="sonata.block.template">
-                <source>sonata.block.template</source>
+            <trans-unit id="sonata.block.service.template">
+                <source>sonata.block.service.template</source>
                 <target>Vue Partielle</target>
             </trans-unit>
         </body>

--- a/Resources/translations/SonataBlockBundle.hu.xliff
+++ b/Resources/translations/SonataBlockBundle.hu.xliff
@@ -2,24 +2,24 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="hu" datatype="plaintext" original="SonataBlockBundle.en.xliff">
         <body>
-            <trans-unit id="sonata.block.container">
-                <source>sonata.block.container</source>
+            <trans-unit id="sonata.block.service.container">
+                <source>sonata.block.service.container</source>
                 <target>Konténer</target>
             </trans-unit>
-            <trans-unit id="sonata.block.text">
-                <source>sonata.block.text</source>
+            <trans-unit id="sonata.block.service.text">
+                <source>sonata.block.service.text</source>
                 <target>Szöveg</target>
             </trans-unit>
-            <trans-unit id="sonata.block.rss">
-                <source>sonata.block.rss</source>
+            <trans-unit id="sonata.block.service.rss">
+                <source>sonata.block.service.rss</source>
                 <target>RSS hírfolyam</target>
             </trans-unit>
-            <trans-unit id="sonata.block.menu">
-                <source>sonata.block.menu</source>
+            <trans-unit id="sonata.block.service.menu">
+                <source>sonata.block.service.menu</source>
                 <target>Menü</target>
             </trans-unit>
-            <trans-unit id="sonata.block.template">
-                <source>sonata.block.template</source>
+            <trans-unit id="sonata.block.service.template">
+                <source>sonata.block.service.template</source>
                 <target>Sablon</target>
             </trans-unit>
         </body>

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -8,3 +8,7 @@ All the deprecated code introduced on 3.x is removed on 4.0.
 Please read [3.x](https://github.com/sonata-project/SonataAdminBundle/tree/3.x) upgrade guides for more information.
 
 See also the [diff code](https://github.com/sonata-project/SonataAdminBundle/compare/3.x...4.0.0).
+
+## Block id
+
+If you have created a custom `AbstractBlockService` you must now implement the new constructor, because all blocks use the service id as the block id now. Because of that, the translation keys for the block ids have changed from `sonata.block.$NAME` to `sonata.block.service.$NAME`.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

Depends on #344 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

``` markdown
### Changed
- The block name is automatically set via `TweakCompilerPass`
```
### Subject

The id/name of a block is automatically set to the internal service id. This is the same mechanism like creating a admin. You can't declare the block name by yourself anymore.
