### PR TITLE
Override and use Extension::getConfiguration method

### DIFF
--- a/DependencyInjection/SonataBlockExtension.php
+++ b/DependencyInjection/SonataBlockExtension.php
@@ -20,10 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * PageExtension.
- *
- *
- * @author     Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class SonataBlockExtension extends Extension
 {

--- a/DependencyInjection/SonataBlockExtension.php
+++ b/DependencyInjection/SonataBlockExtension.php
@@ -30,7 +30,7 @@ class SonataBlockExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    final public function getConfiguration(array $config, ContainerBuilder $container)
     {
         $bundles = $container->getParameter('kernel.bundles');
 
@@ -45,8 +45,18 @@ class SonataBlockExtension extends Extension
             $defaultTemplates['SonataSeoBundle:Block:block_social_container.html.twig'] = 'SonataSeoBundle (to contain social buttons)';
         }
 
+        return new Configuration($defaultTemplates);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $bundles = $container->getParameter('kernel.bundles');
+
         $processor = new Processor();
-        $configuration = new Configuration($defaultTemplates);
+        $configuration = $this->getConfiguration($configs, $container);
         $config = $processor->processConfiguration($configuration, $configs);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));


### PR DESCRIPTION
Fixes #303 

### Changelog

```markdown
### Fixed
- Error with the default extension configuration for `config:dump-reference` command
```

### Subject

The `Configuration` class constructor needs `$defaultContainerTemplates` argument.

This is not provided on the default `Extension::getConfiguration` method.

The bundle is working, but some functionalities like `app/console config:dump-reference sonata_block` might fail.

@stphnpt can you please confirm this fix your issue?