### PR TITLE
Use correct namespace for custom phpunit test cases

### DIFF
--- a/Test/AbstractBlockServiceTestCase.php
+++ b/Test/AbstractBlockServiceTestCase.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Test;
+
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\BlockContextManager;
+use Sonata\BlockBundle\Block\BlockContextManagerInterface;
+use Sonata\BlockBundle\Block\BlockServiceInterface;
+use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
+use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Abstract test class for block service tests.
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+abstract class AbstractBlockServiceTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|BlockServiceManagerInterface
+     */
+    protected $blockServiceManager;
+
+    /**
+     * @var BlockContextManagerInterface
+     */
+    protected $blockContextManager;
+
+    /**
+     * @var FakeTemplating
+     */
+    protected $templating;
+
+    protected function setUp()
+    {
+        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->templating = new FakeTemplating();
+
+        $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
+        $this->blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $this->blockContextManager = new BlockContextManager($blockLoader, $this->blockServiceManager);
+    }
+
+    protected function getBlockContext(BlockServiceInterface $blockService)
+    {
+        $this->blockServiceManager->expects($this->once())->method('get')->will($this->returnValue($blockService));
+
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block->expects($this->once())->method('getSettings')->will($this->returnValue(array()));
+
+        $blockContext = $this->blockContextManager->get($block);
+        $this->assertInstanceOf('Sonata\BlockBundle\Block\BlockContextInterface', $blockContext);
+
+        return $blockContext;
+    }
+
+    protected function assertSettings(array $expected, BlockContextInterface $blockContext)
+    {
+        $completeExpectedOptions = array_merge(array(
+            'use_cache' => true,
+            'extra_cache_keys' => array(),
+            'attr' => array(),
+            'template' => false,
+            'ttl' => 0,
+        ), $expected);
+
+        ksort($completeExpectedOptions);
+        $blockSettings = $blockContext->getSettings();
+        ksort($blockSettings);
+
+        $this->assertSame($completeExpectedOptions, $blockSettings);
+    }
+}

--- a/Tests/Block/AbstractBlockServiceTest.php
+++ b/Tests/Block/AbstractBlockServiceTest.php
@@ -11,78 +11,18 @@
 
 namespace Sonata\BlockBundle\Tests\Block;
 
-use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\BlockContextManager;
-use Sonata\BlockBundle\Block\BlockContextManagerInterface;
-use Sonata\BlockBundle\Block\BlockServiceInterface;
-use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
-use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+
+@trigger_error(
+    'The '.__NAMESPACE__.'\AbstractBlockServiceTest class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase instead.',
+    E_USER_DEPRECATED
+);
+
 
 /**
- * Abstract test class for block service tests.
- *
- * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ * @deprecated Deprecated since version 3.x. Use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase instead.
  */
-abstract class AbstractBlockServiceTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractBlockServiceTest extends AbstractBlockServiceTestCase
 {
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface
-     */
-    protected $container;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|BlockServiceManagerInterface
-     */
-    protected $blockServiceManager;
-
-    /**
-     * @var BlockContextManagerInterface
-     */
-    protected $blockContextManager;
-
-    /**
-     * @var FakeTemplating
-     */
-    protected $templating;
-
-    protected function setUp()
-    {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->templating = new FakeTemplating();
-
-        $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
-        $this->blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
-        $this->blockContextManager = new BlockContextManager($blockLoader, $this->blockServiceManager);
-    }
-
-    protected function getBlockContext(BlockServiceInterface $blockService)
-    {
-        $this->blockServiceManager->expects($this->once())->method('get')->will($this->returnValue($blockService));
-
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
-        $block->expects($this->once())->method('getSettings')->will($this->returnValue(array()));
-
-        $blockContext = $this->blockContextManager->get($block);
-        $this->assertInstanceOf('Sonata\BlockBundle\Block\BlockContextInterface', $blockContext);
-
-        return $blockContext;
-    }
-
-    protected function assertSettings(array $expected, BlockContextInterface $blockContext)
-    {
-        $completeExpectedOptions = array_merge(array(
-            'use_cache' => true,
-            'extra_cache_keys' => array(),
-            'attr' => array(),
-            'template' => false,
-            'ttl' => 0,
-        ), $expected);
-
-        ksort($completeExpectedOptions);
-        $blockSettings = $blockContext->getSettings();
-        ksort($blockSettings);
-
-        $this->assertSame($completeExpectedOptions, $blockSettings);
-    }
 }

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,0 +1,6 @@
+UPGRADE 3.x
+===========
+
+## Deprecated AbstractBlockServiceTest class
+
+The `Tests\Block\AbstractBlockServiceTest` class is deprecated. Use `Test\AbstractBlockServiceTestCase` instead.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
 - Deprecate `Tests\Block\AbstractBlockServiceTest` in favor of `Test\AbstractBlockServiceTestCase`
```

## Subject

Use the correct namespace for abstract `TestCase`s, so they will be loaded when excluding the `tests` directory in the (non dev-)autoloader.
