### PR TITLE
Move FakeTemplating to public test namespace

### DIFF
--- a/Test/AbstractBlockServiceTestCase.php
+++ b/Test/AbstractBlockServiceTestCase.php
@@ -16,7 +16,6 @@ use Sonata\BlockBundle\Block\BlockContextManager;
 use Sonata\BlockBundle\Block\BlockContextManagerInterface;
 use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
-use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/Test/FakeTemplating.php
+++ b/Test/FakeTemplating.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Test;
+
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Mocking class for template usage.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+class FakeTemplating implements EngineInterface
+{
+    /**
+     * @var string
+     */
+    public $view;
+
+    /**
+     * @var array
+     */
+    public $parameters;
+
+    /**
+     * @var Response
+     */
+    public $response;
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render($name, array $parameters = array())
+    {
+        $this->name = $name;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderResponse($view, array $parameters = array(), Response $response = null)
+    {
+        $this->view = $view;
+        $this->parameters = $parameters;
+        $this->response = $response;
+
+        if ($response) {
+            return $response;
+        }
+
+        return new Response();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($name)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function exists($name)
+    {
+        return true;
+    }
+}

--- a/Tests/Block/Service/FakeTemplating.php
+++ b/Tests/Block/Service/FakeTemplating.php
@@ -11,68 +11,17 @@
 
 namespace Sonata\BlockBundle\Tests\Block\Service;
 
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Symfony\Component\HttpFoundation\Response;
+use Sonata\BlockBundle\Test\FakeTemplating as BaseTemplating;
 
-class FakeTemplating implements EngineInterface
+@trigger_error(
+    'The '.__NAMESPACE__.'\FakeTemplating class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use Sonata\BlockBundle\Test\FakeTemplating instead.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated since version 3.x and will be removed in 4.0. Use Sonata\BlockBundle\Test\FakeTemplating instead.
+ */
+class FakeTemplating extends BaseTemplating
 {
-    /**
-     * @var string
-     */
-    public $view;
-
-    /**
-     * @var array
-     */
-    public $parameters;
-
-    /**
-     * @var Response
-     */
-    public $response;
-
-    /**
-     * @var string
-     */
-    public $name;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function render($name, array $parameters = array())
-    {
-        $this->name = $name;
-        $this->parameters = $parameters;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function renderResponse($view, array $parameters = array(), Response $response = null)
-    {
-        $this->view = $view;
-        $this->parameters = $parameters;
-
-        if ($response) {
-            return $response;
-        }
-
-        return new Response();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supports($name)
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function exists($name)
-    {
-        return true;
-    }
 }

--- a/Tests/Test/FakeTemplatingTest.php
+++ b/Tests/Test/FakeTemplatingTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Test;
+
+use Sonata\BlockBundle\Test\FakeTemplating;
+
+class FakeTemplatingTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRender()
+    {
+        $templating = new FakeTemplating();
+        $templating->render('template.html.twig', array(
+            'foo' => 'bar',
+        ));
+
+        $this->assertSame('template.html.twig', $templating->name);
+        $this->assertSame(array(
+            'foo' => 'bar',
+        ), $templating->parameters);
+    }
+
+    public function testRenderResponse()
+    {
+        $response = $this->getMockBuilder('Symfony\Component\HttpFoundation\Response')->getMock();
+
+        $templating = new FakeTemplating();
+        $templating->renderResponse('template.html.twig', array(
+            'foo' => 'bar',
+        ), $response);
+
+        $this->assertSame('template.html.twig', $templating->view);
+        $this->assertSame(array(
+            'foo' => 'bar',
+        ), $templating->parameters);
+        $this->assertSame($response, $templating->response);
+    }
+
+    public function testSupports()
+    {
+        $templating = new FakeTemplating();
+        $this->assertTrue($templating->supports('foo'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testExists()
+    {
+        $templating = new FakeTemplating();
+        $this->assertTrue($templating->exists('foo'));
+    }
+}

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,11 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated test classes
+
+The `Tests\Block\Service\FakeTemplating` class is deprecated. Use `Test\FakeTemplating` instead.
+
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC with a deprecation notice.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate `Tests\Block\Service\FakeTemplating` in favor of `Test\Mock\MockTemplating`
```
## Subject

The `FakeTemplating` class is used across several bundles and should be shared in the public `Test` namespace.

### SonataDashboardBundle
Tests/Block/ContainerBlockServiceTest.php:use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;

### SonataMediaBundle
Tests/Block/GalleryListBlockServiceTest.php:use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;


### SonataPageBundle
Tests/Block/PageListBlockServiceTest.php:use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;

### SonataSeoBundle
Tests/Block/Social/FacebookLikeBoxBlockServiceTest.php:use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
Tests/Block/Social/FacebookLikeButtonBlockServiceTest.php:use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
Tests/Block/Social/FacebookSendButtonBlockServiceTest.php:use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
Tests/Block/Social/FacebookShareButtonBlockServiceTest.php:use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
