### PR TITLE
Use AbstractBlockServiceTestCase in tests

### DIFF
--- a/Tests/Block/Service/BaseTestBlockService.php
+++ b/Tests/Block/Service/BaseTestBlockService.php
@@ -11,6 +11,14 @@
 
 namespace Sonata\BlockBundle\Tests\Block\Service;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\BaseTestBlockService class is deprecated since version 3.x and will be removed in 4.0.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated Deprecated since version 3.x and will be removed in 4.0.
+ */
 class BaseTestBlockService extends \PHPUnit_Framework_TestCase
 {
 }

--- a/Tests/Block/Service/RssBlockServiceTest.php
+++ b/Tests/Block/Service/RssBlockServiceTest.php
@@ -14,17 +14,17 @@ namespace Sonata\BlockBundle\Tests\Block\Service;
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Block\Service\RssBlockService;
 use Sonata\BlockBundle\Model\Block;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\BlockBundle\Util\OptionsResolver;
 
-class RssBlockServiceTest extends BaseTestBlockService
+class RssBlockServiceTest extends AbstractBlockServiceTestCase
 {
     /*
      * only test if the API is not broken
      */
     public function testService()
     {
-        $templating = new FakeTemplating();
-        $service = new RssBlockService('sonata.page.block.rss', $templating);
+        $service = new RssBlockService('sonata.page.block.rss', $this->templating);
 
         $block = new Block();
         $block->setType('core.text');

--- a/Tests/Block/Service/TextBlockServiceTest.php
+++ b/Tests/Block/Service/TextBlockServiceTest.php
@@ -14,14 +14,14 @@ namespace Sonata\BlockBundle\Tests\Block\Service;
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Block\Service\TextBlockService;
 use Sonata\BlockBundle\Model\Block;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\BlockBundle\Util\OptionsResolver;
 
-class TextBlockServiceTest extends BaseTestBlockService
+class TextBlockServiceTest extends AbstractBlockServiceTestCase
 {
     public function testService()
     {
-        $templating = new FakeTemplating();
-        $service = new TextBlockService('sonata.page.block.text', $templating);
+        $service = new TextBlockService('sonata.page.block.text', $this->templating);
 
         $block = new Block();
         $block->setType('core.text');
@@ -42,6 +42,6 @@ class TextBlockServiceTest extends BaseTestBlockService
 
         $response = $service->execute($blockContext);
 
-        $this->assertEquals('my text', $templating->parameters['settings']['content']);
+        $this->assertEquals('my text', $this->templating->parameters['settings']['content']);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a minor change with a deprecation.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Tests for `*BlockService*` now uses `AbstractBlockServiceTestCase`

### Deprecated
- Deprecate empty class `BaseTestBlockService`
```

## Subject

All tests for block services should use the abstract test case.

