### PR TITLE
Deprecate BaseBlockService and BlockAdminServiceInterface

### DIFF
--- a/Block/AbstractBlockService.php
+++ b/Block/AbstractBlockService.php
@@ -11,30 +11,19 @@
 
 namespace Sonata\BlockBundle\Block;
 
-use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+@trigger_error(
+    'This class is deprecated since 3.x and will be removed with the 4.0 release.'.
+    'Use '.__NAMESPACE__.'\Block\Service\AbstractBlockService instead.',
+    E_USER_DEPRECATED
+);
 
 /**
  * Class AbstractBlockService.
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ *
+ * @deprecated since 3.x, to be removed with 4.0
  */
-abstract class AbstractBlockService implements BlockServiceInterface
+abstract class AbstractBlockService extends \Sonata\BlockBundle\Block\Service\AbstractBlockService
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
-    {
-        $this->configureSettings($resolver);
-    }
-
-    /**
-     * Define the default options for the block.
-     *
-     * @param OptionsResolver $resolver
-     */
-    public function configureSettings(OptionsResolver $resolver)
-    {
-    }
 }

--- a/Block/BaseBlockService.php
+++ b/Block/BaseBlockService.php
@@ -11,204 +11,22 @@
 
 namespace Sonata\BlockBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Model\Metadata;
-use Sonata\CoreBundle\Validator\ErrorElement;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Symfony\Component\HttpFoundation\Response;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+
+@trigger_error(
+    'This class is deprecated since 3.x and will be removed with the 4.0 release.'.
+    'Use '.__NAMESPACE__.'\Block\Service\AbstractBlockService instead.',
+    E_USER_DEPRECATED
+);
 
 /**
  * BaseBlockService.
  *
  *
  * @author     Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @deprecated since 3.x, to be removed with 4.0
  */
-abstract class BaseBlockService extends AbstractBlockService implements BlockAdminServiceInterface
+abstract class BaseBlockService extends AbstractAdminBlockService implements BlockAdminServiceInterface
 {
-    /**
-     * @var string
-     */
-    protected $name;
-
-    /**
-     * @var EngineInterface
-     */
-    protected $templating;
-
-    /**
-     * @param string          $name
-     * @param EngineInterface $templating
-     */
-    public function __construct($name, EngineInterface $templating)
-    {
-        $this->name = $name;
-        $this->templating = $templating;
-    }
-
-    /**
-     * Returns a Response object than can be cacheable.
-     *
-     * @param string   $view
-     * @param array    $parameters
-     * @param Response $response
-     *
-     * @return Response
-     */
-    public function renderResponse($view, array $parameters = array(), Response $response = null)
-    {
-        return $this->getTemplating()->renderResponse($view, $parameters, $response);
-    }
-
-    /**
-     * Returns a Response object that cannot be cacheable, this must be used if the Response is related to the user.
-     * A good solution to make the page cacheable is to configure the block to be cached with javascript ...
-     *
-     * @param string   $view
-     * @param array    $parameters
-     * @param Response $response
-     *
-     * @return Response
-     */
-    public function renderPrivateResponse($view, array $parameters = array(), Response $response = null)
-    {
-        return $this->renderResponse($view, $parameters, $response)
-            ->setTtl(0)
-            ->setPrivate()
-        ;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTemplating()
-    {
-        return $this->templating;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
-    {
-        $this->buildEditForm($formMapper, $block);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getCacheKeys(BlockInterface $block)
-    {
-        return array(
-            'block_id' => $block->getId(),
-            'updated_at' => $block->getUpdatedAt() ? $block->getUpdatedAt()->format('U') : strtotime('now'),
-        );
-    }
-
-    /**
-     * @param BlockInterface $block
-     */
-    public function prePersist(BlockInterface $block)
-    {
-    }
-
-    /**
-     * @param BlockInterface $block
-     */
-    public function postPersist(BlockInterface $block)
-    {
-    }
-
-    /**
-     * @param BlockInterface $block
-     */
-    public function preUpdate(BlockInterface $block)
-    {
-    }
-
-    /**
-     * @param BlockInterface $block
-     */
-    public function postUpdate(BlockInterface $block)
-    {
-    }
-
-    /**
-     * @param BlockInterface $block
-     */
-    public function preRemove(BlockInterface $block)
-    {
-    }
-
-    /**
-     * @param BlockInterface $block
-     */
-    public function postRemove(BlockInterface $block)
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function load(BlockInterface $block)
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getJavascripts($media)
-    {
-        return array();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getStylesheets($media)
-    {
-        return array();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function execute(BlockContextInterface $blockContext, Response $response = null)
-    {
-        return $this->renderResponse($blockContext->getTemplate(), array(
-            'block_context' => $blockContext,
-            'block' => $blockContext->getBlock(),
-        ), $response);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildEditForm(FormMapper $form, BlockInterface $block)
-    {
-    }
-
-    /**
-     * @param ErrorElement   $errorElement
-     * @param BlockInterface $block
-     */
-    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockMetadata($code = null)
-    {
-        return new Metadata($this->getName(), (!is_null($code) ? $code : $this->getName()), false, 'SonataBlockBundle', array('class' => 'fa fa-file'));
-    }
 }

--- a/Block/BlockAdminServiceInterface.php
+++ b/Block/BlockAdminServiceInterface.php
@@ -11,35 +11,17 @@
 
 namespace Sonata\BlockBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\CoreBundle\Model\MetadataInterface;
-use Sonata\CoreBundle\Validator\ErrorElement;
+use Sonata\BlockBundle\Block\Service\AdminBlockServiceInterface;
 
-interface BlockAdminServiceInterface
+@trigger_error(
+    'This class is deprecated since 3.x and will be removed with the 4.0 release.'.
+    'Use '.__NAMESPACE__.'\Block\Service\AdminBlockServiceInterface instead.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated since 3.x, to be removed with 4.0
+ */
+interface BlockAdminServiceInterface extends AdminBlockServiceInterface
 {
-    /**
-     * @param FormMapper     $form
-     * @param BlockInterface $block
-     */
-    public function buildEditForm(FormMapper $form, BlockInterface $block);
-
-    /**
-     * @param FormMapper     $form
-     * @param BlockInterface $block
-     */
-    public function buildCreateForm(FormMapper $form, BlockInterface $block);
-
-    /**
-     * @param ErrorElement   $errorElement
-     * @param BlockInterface $block
-     */
-    public function validateBlock(ErrorElement $errorElement, BlockInterface $block);
-
-    /**
-     * @param string|null $code
-     *
-     * @return MetadataInterface
-     */
-    public function getBlockMetadata($code = null);
 }

--- a/Block/BlockServiceInterface.php
+++ b/Block/BlockServiceInterface.php
@@ -11,62 +11,17 @@
 
 namespace Sonata\BlockBundle\Block;
 
-use Sonata\BlockBundle\Model\BlockInterface;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+@trigger_error(
+    'This class is deprecated since 3.x and will be removed with the 4.0 release.'.
+    'Use '.__NAMESPACE__.'\Block\BlockServiceInterface instead.',
+    E_USER_DEPRECATED
+);
 
 /**
  * Interface BlockServiceInterface.
+ *
+ * @deprecated since 3.x, to be removed with 4.0
  */
-interface BlockServiceInterface
+interface BlockServiceInterface extends \Sonata\BlockBundle\Block\Service\BlockServiceInterface
 {
-    /**
-     * @param BlockContextInterface $blockContext
-     * @param Response              $response
-     *
-     * @return Response
-     */
-    public function execute(BlockContextInterface $blockContext, Response $response = null);
-
-    /**
-     * @return string
-     */
-    public function getName();
-
-    /**
-     * Define the default options for the block.
-     *
-     * @param OptionsResolverInterface $resolver
-     *
-     * @deprecated since version 2.3, to be renamed in 3.0.
-     *             Use the method configureSettings instead.
-     *             This method will be added to the BlockServiceInterface with SonataBlockBundle 3.0
-     */
-    public function setDefaultSettings(OptionsResolverInterface $resolver);
-
-    /**
-     * @param BlockInterface $block
-     */
-    public function load(BlockInterface $block);
-
-    /**
-     * @param $media
-     *
-     * @return array
-     */
-    public function getJavascripts($media);
-
-    /**
-     * @param $media
-     *
-     * @return array
-     */
-    public function getStylesheets($media);
-
-    /**
-     * @param BlockInterface $block
-     *
-     * @return array
-     */
-    public function getCacheKeys(BlockInterface $block);
 }

--- a/Block/Service/AbstractAdminBlockService.php
+++ b/Block/Service/AbstractAdminBlockService.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Block\Service;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Model\Metadata;
+use Sonata\CoreBundle\Validator\ErrorElement;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+abstract class AbstractAdminBlockService extends AbstractBlockService implements AdminBlockServiceInterface
+{
+    /**
+     * @param string          $name
+     * @param EngineInterface $templating
+     */
+    public function __construct($name, EngineInterface $templating)
+    {
+        parent::__construct($name, $templating);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $this->buildEditForm($formMapper, $block);
+    }
+
+    /**
+     * @param BlockInterface $block
+     */
+    public function prePersist(BlockInterface $block)
+    {
+    }
+
+    /**
+     * @param BlockInterface $block
+     */
+    public function postPersist(BlockInterface $block)
+    {
+    }
+
+    /**
+     * @param BlockInterface $block
+     */
+    public function preUpdate(BlockInterface $block)
+    {
+    }
+
+    /**
+     * @param BlockInterface $block
+     */
+    public function postUpdate(BlockInterface $block)
+    {
+    }
+
+    /**
+     * @param BlockInterface $block
+     */
+    public function preRemove(BlockInterface $block)
+    {
+    }
+
+    /**
+     * @param BlockInterface $block
+     */
+    public function postRemove(BlockInterface $block)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildEditForm(FormMapper $form, BlockInterface $block)
+    {
+    }
+
+    /**
+     * @param ErrorElement   $errorElement
+     * @param BlockInterface $block
+     */
+    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockMetadata($code = null)
+    {
+        return new Metadata($this->getName(), (!is_null($code) ? $code : $this->getName()), false, 'SonataBlockBundle', array('class' => 'fa fa-file'));
+    }
+}

--- a/Block/Service/AbstractBlockService.php
+++ b/Block/Service/AbstractBlockService.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Block\Service;
+
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+abstract class AbstractBlockService implements BlockServiceInterface
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var EngineInterface
+     */
+    protected $templating;
+
+    /**
+     * @param string          $name
+     * @param EngineInterface $templating
+     */
+    public function __construct($name = null, EngineInterface $templating = null)
+    {
+        if (null === $name || null === $templating) {
+            @trigger_error(
+                'The $name and $templating parameters will be required fields with the 4.0 release.',
+                E_USER_DEPRECATED
+            );
+        }
+
+        $this->name = $name;
+        $this->templating = $templating;
+    }
+
+    /**
+     * Returns a Response object than can be cacheable.
+     *
+     * @param string   $view
+     * @param array    $parameters
+     * @param Response $response
+     *
+     * @return Response
+     */
+    public function renderResponse($view, array $parameters = array(), Response $response = null)
+    {
+        return $this->getTemplating()->renderResponse($view, $parameters, $response);
+    }
+
+    /**
+     * Returns a Response object that cannot be cacheable, this must be used if the Response is related to the user.
+     * A good solution to make the page cacheable is to configure the block to be cached with javascript ...
+     *
+     * @param string   $view
+     * @param array    $parameters
+     * @param Response $response
+     *
+     * @return Response
+     */
+    public function renderPrivateResponse($view, array $parameters = array(), Response $response = null)
+    {
+        return $this->renderResponse($view, $parameters, $response)
+            ->setTtl(0)
+            ->setPrivate()
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    {
+        $this->configureSettings($resolver);
+    }
+
+    /**
+     * Define the default options for the block.
+     *
+     * @param OptionsResolver $resolver
+     */
+    public function configureSettings(OptionsResolver $resolver)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheKeys(BlockInterface $block)
+    {
+        return array(
+            'block_id' => $block->getId(),
+            'updated_at' => $block->getUpdatedAt() ? $block->getUpdatedAt()->format('U') : strtotime('now'),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(BlockInterface $block)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJavascripts($media)
+    {
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStylesheets($media)
+    {
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    {
+        return $this->renderResponse($blockContext->getTemplate(), array(
+            'block_context' => $blockContext,
+            'block' => $blockContext->getBlock(),
+        ), $response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplating()
+    {
+        return $this->templating;
+    }
+}

--- a/Block/Service/AdminBlockServiceInterface.php
+++ b/Block/Service/AdminBlockServiceInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Block\Service;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Model\MetadataInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+interface AdminBlockServiceInterface extends BlockServiceInterface
+{
+    /**
+     * @param FormMapper     $form
+     * @param BlockInterface $block
+     */
+    public function buildEditForm(FormMapper $form, BlockInterface $block);
+
+    /**
+     * @param FormMapper     $form
+     * @param BlockInterface $block
+     */
+    public function buildCreateForm(FormMapper $form, BlockInterface $block);
+
+    /**
+     * @param ErrorElement   $errorElement
+     * @param BlockInterface $block
+     */
+    public function validateBlock(ErrorElement $errorElement, BlockInterface $block);
+
+    /**
+     * @param string|null $code
+     *
+     * @return MetadataInterface
+     */
+    public function getBlockMetadata($code = null);
+}

--- a/Block/Service/BlockServiceInterface.php
+++ b/Block/Service/BlockServiceInterface.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Block\Service;
+
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+interface BlockServiceInterface
+{
+    /**
+     * @param BlockContextInterface $blockContext
+     * @param Response              $response
+     *
+     * @return Response
+     */
+    public function execute(BlockContextInterface $blockContext, Response $response = null);
+
+    /**
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Define the default options for the block.
+     *
+     * @param OptionsResolverInterface $resolver
+     *
+     * @deprecated since version 2.3, to be renamed in 3.0.
+     *             Use the method configureSettings instead.
+     *             This method will be added to the BlockServiceInterface with SonataBlockBundle 3.0
+     */
+    public function setDefaultSettings(OptionsResolverInterface $resolver);
+
+    /**
+     * @param BlockInterface $block
+     */
+    public function load(BlockInterface $block);
+
+    /**
+     * @param $media
+     *
+     * @return array
+     */
+    public function getJavascripts($media);
+
+    /**
+     * @param $media
+     *
+     * @return array
+     */
+    public function getStylesheets($media);
+
+    /**
+     * @param BlockInterface $block
+     *
+     * @return array
+     */
+    public function getCacheKeys(BlockInterface $block);
+}

--- a/Block/Service/ContainerBlockService.php
+++ b/Block/Service/ContainerBlockService.php
@@ -12,7 +12,6 @@
 namespace Sonata\BlockBundle\Block\Service;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\Metadata;
@@ -24,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class ContainerBlockService extends BaseBlockService
+class ContainerBlockService extends AbstractAdminBlockService
 {
     /**
      * {@inheritdoc}

--- a/Block/Service/EmptyBlockService.php
+++ b/Block/Service/EmptyBlockService.php
@@ -12,14 +12,15 @@
 namespace Sonata\BlockBundle\Block\Service;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\HttpFoundation\Response;
 
-class EmptyBlockService extends BaseBlockService
+class EmptyBlockService extends AbstractBlockService
 {
+    // NEXT_MAJOR: Remove this method
+
     /**
      * {@inheritdoc}
      */
@@ -27,6 +28,8 @@ class EmptyBlockService extends BaseBlockService
     {
         throw new \RuntimeException('Not used, this block renders an empty result if no block document can be found');
     }
+
+    // NEXT_MAJOR: Remove this method
 
     /**
      * {@inheritdoc}

--- a/Block/Service/MenuBlockService.php
+++ b/Block/Service/MenuBlockService.php
@@ -14,7 +14,6 @@ namespace Sonata\BlockBundle\Block\Service;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\Metadata;
@@ -29,7 +28,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Hugo Briand <briand@ekino.com>
  */
-class MenuBlockService extends BaseBlockService
+class MenuBlockService extends AbstractAdminBlockService
 {
     /**
      * @var MenuProviderInterface

--- a/Block/Service/RssBlockService.php
+++ b/Block/Service/RssBlockService.php
@@ -12,7 +12,6 @@
 namespace Sonata\BlockBundle\Block\Service;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\Metadata;
@@ -23,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author     Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class RssBlockService extends BaseBlockService
+class RssBlockService extends AbstractAdminBlockService
 {
     /**
      * {@inheritdoc}

--- a/Block/Service/TemplateBlockService.php
+++ b/Block/Service/TemplateBlockService.php
@@ -12,7 +12,6 @@
 namespace Sonata\BlockBundle\Block\Service;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\Metadata;
@@ -22,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author     Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class TemplateBlockService extends BaseBlockService
+class TemplateBlockService extends AbstractAdminBlockService
 {
     /**
      * {@inheritdoc}

--- a/Block/Service/TextBlockService.php
+++ b/Block/Service/TextBlockService.php
@@ -12,7 +12,6 @@
 namespace Sonata\BlockBundle\Block\Service;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\Metadata;
@@ -22,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author     Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class TextBlockService extends BaseBlockService
+class TextBlockService extends AbstractAdminBlockService
 {
     /**
      * {@inheritdoc}

--- a/Resources/doc/reference/your_first_block.rst
+++ b/Resources/doc/reference/your_first_block.rst
@@ -13,7 +13,7 @@ A `block service` is just a service which must implement the ``BlockServiceInter
 First namespaces
 ----------------
 
-The ``BaseBlockService`` implements some basic methods defined by the interface.
+The ``AbstractBlockService`` implements some basic methods defined by the interface.
 The current RSS block will extend this base class. The other `use` statements are required by the interface's remaining methods.
 
 .. code-block:: php
@@ -30,7 +30,7 @@ The current RSS block will extend this base class. The other `use` statements ar
 
     use Sonata\AdminBundle\Form\FormMapper;
     use Sonata\CoreBundle\Validator\ErrorElement;
-    use Sonata\BlockBundle\Block\BaseBlockService;
+    use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 
 Default settings
 ----------------

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,13 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated block classes and interfaces
+
+The `Sonata\BlockBundle\Block\AbstractBlockService` and `Sonata\BlockBundle\Block\BaseBlockService` classes are deprecated.
+Use `Sonata\BlockBundle\Block\AbstractBlockService` for normal blocks or `Sonata\BlockBundle\Block\AbstractAdminBlockService` for manageable blocks instead.
+
+The interfaces `Sonata\BlockBundle\Block\BlockServiceInterface` and `Sonata\BlockBundle\Block\BlockAdminServiceInterface` are deprecated.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- created `Sonata\BlockBundle\Block\Service\AbstractAdminBlockService` class
- created `Sonata\BlockBundle\Block\Service\AbstractBlockService` class
- created `Sonata\BlockBundle\Block\Service\AdminBlockServiceInterface` class
- created `Sonata\BlockBundle\Block\Service\BlockServiceInterface` class

### Deprecated
- the class `Sonata\BlockBundle\Block\AbstractBlockService` is deprecated
- the class `Sonata\BlockBundle\Block\BaseBlockService` is deprecated
- the class `Sonata\BlockBundle\Block\BlockAdminServiceInterface` is deprecated
- the class `Sonata\BlockBundle\Block\BlockServiceInterface` is deprecated

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [X] Update the tests
- [x] Update the documentation
- [X] Add an upgrade note

## Subject

The class BaseBlockService doesn't match the correct naming convention and starts with Base instead of Abstract. The BaseBlockService class contains special methods for the admin bundle, so should be moved to special class.


