### PR TITLE
Added missing method in EmptyBlockService

### DIFF
--- a/Block/Service/EmptyBlockService.php
+++ b/Block/Service/EmptyBlockService.php
@@ -17,9 +17,17 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EmptyBlockService extends BaseBlockService
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureSettings(OptionsResolver $resolver)
+    {
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixed #322

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed missing method in `EmptyBlockService`
```

## Subject

Fixed PR #323.

