### PR TITLE
Deprecated class removal

### DIFF
--- a/DependencyInjection/SonataBlockExtension.php
+++ b/DependencyInjection/SonataBlockExtension.php
@@ -274,7 +274,6 @@ class SonataBlockExtension extends Extension
     public function configureClassesToCompile()
     {
         $this->addClassesToCompile(array(
-            'Sonata\\BlockBundle\\Block\\BaseBlockService',
             'Sonata\\BlockBundle\\Block\\BlockLoaderChain',
             'Sonata\\BlockBundle\\Block\\BlockLoaderInterface',
             'Sonata\\BlockBundle\\Block\\BlockRenderer',


### PR DESCRIPTION
Deprecated class removal
## Changelog

```markdown
### Removed
- deprecated `BaseBlockService` class was removed from the list of classes to compile
```
