### PR TITLE
Created menu manager for MenuBlockService

### DIFF
--- a/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -28,6 +28,7 @@ class TweakCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $manager = $container->getDefinition('sonata.block.manager');
+        $registry = $container->getDefinition('sonata.block.menu.registry');
 
         $parameters = $container->getParameter('sonata_block.blocks');
 
@@ -48,6 +49,10 @@ class TweakCompilerPass implements CompilerPassInterface
             }
 
             $manager->addMethodCall('add', array($id, $id, isset($parameters[$id]) ? $parameters[$id]['contexts'] : array()));
+        }
+
+        foreach ($container->findTaggedServiceIds('sonata.block.menu') as $id => $attributes) {
+            $registry->addMethodCall('add', array(new Reference($id)));
         }
 
         $services = array();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -164,6 +164,18 @@ class Configuration implements ConfigurationInterface
                     ->info('KNP Menus available in sonata.block.menu block configuration')
                     ->useAttributeAsKey('id')
                     ->prototype('scalar')->end()
+                    ->validate()
+                        ->always(function ($value) {
+                            if (count($value) > 0) {
+                                @trigger_error(
+                                    'The menus configuration key is deprecated since 3.x and will be removed in 4.0.',
+                                    E_USER_DEPRECATED
+                                );
+                            }
+
+                            return $value;
+                        })
+                    ->end()
                 ->end()
 
                 ->arrayNode('blocks_by_class')

--- a/DependencyInjection/SonataBlockExtension.php
+++ b/DependencyInjection/SonataBlockExtension.php
@@ -121,7 +121,7 @@ class SonataBlockExtension extends Extension
             return;
         }
 
-        $container->getDefinition('sonata.block.service.menu')->replaceArgument(3, $config['menus']);
+        $container->getDefinition('sonata.block.menu.registry')->replaceArgument(0, $config['menus']);
     }
 
     /**

--- a/Menu/MenuBuilderInterface.php
+++ b/Menu/MenuBuilderInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Menu;
+
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+interface MenuBuilderInterface
+{
+    /**
+     * Create a knp menu.
+     *
+     * @param FactoryInterface $factory
+     * @param array            $options
+     *
+     * @return ItemInterface
+     */
+    public function buildMenu(FactoryInterface $factory, array $options);
+
+    /**
+     * Return the name.
+     *
+     * @return string
+     */
+    public function getName();
+}

--- a/Menu/MenuRegistry.php
+++ b/Menu/MenuRegistry.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Menu;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+final class MenuRegistry implements MenuRegistryInterface
+{
+    /**
+     * @var MenuBuilderInterface[]
+     */
+    private $menus = array();
+
+    /**
+     * @var string[]
+     */
+    private $names = array();
+
+    /**
+     * MenuRegistry constructor.
+     *
+     * @param string[] $menus
+     *
+     * NEXT_MAJOR: remove constructor parameter
+     */
+    public function __construct($menus = null)
+    {
+        if (null != $menus) {
+            $this->names = $menus;
+
+            @trigger_error(
+                'The menus parameter in '.__CLASS__.' is deprecated since 3.x and will be removed in 4.0.',
+                E_USER_DEPRECATED
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function add(MenuBuilderInterface $menu)
+    {
+        $alias = $this->buildMenuAlias($menu);
+
+        $this->menus[$alias] = $menu;
+        $this->names[$alias] = $menu->getName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliasNames()
+    {
+        return $this->names;
+    }
+
+    /**
+     * Returns the menu method name.
+     *
+     * @param MenuBuilderInterface $menu
+     *
+     * @return string
+     */
+    private function buildMenuAlias(MenuBuilderInterface $menu)
+    {
+        $reflector = new \ReflectionClass($menu);
+        $namespace = $reflector->getNamespaceName();
+        $class = $reflector->getName();
+
+        $bundle = str_replace('\\', '', preg_replace('/(.*Bundle)\\\\.*/i', '$1', $namespace));
+
+        return $bundle.':'.$class.':buildMenu';
+    }
+}

--- a/Menu/MenuRegistryInterface.php
+++ b/Menu/MenuRegistryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Menu;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+interface MenuRegistryInterface
+{
+    /**
+     * Adds a new menu.
+     *
+     * @param MenuBuilderInterface $name
+     */
+    public function add(MenuBuilderInterface $name);
+
+    /**
+     * Returns all alias names.
+     *
+     * @return string[]
+     */
+    public function getAliasNames();
+}

--- a/Resources/config/block.xml
+++ b/Resources/config/block.xml
@@ -34,7 +34,7 @@
             <argument>sonata.block.menu</argument>
             <argument type="service" id="templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
-            <argument type="collection"/>
+            <argument type="service" id="sonata.block.menu.registry"/>
         </service>
         <service id="sonata.block.service.template" class="%sonata.block.service.template.class%">
             <tag name="sonata.block"/>

--- a/Resources/config/core.xml
+++ b/Resources/config/core.xml
@@ -6,6 +6,9 @@
             <argument>%kernel.debug%</argument>
             <argument type="service" id="logger" on-invalid="ignore"/>
         </service>
+        <service id="sonata.block.menu.registry" class="Sonata\BlockBundle\Menu\MenuRegistry">
+            <argument/>
+        </service>
         <service id="sonata.block.context_manager.default" class="Sonata\BlockBundle\Block\BlockContextManager">
             <argument type="service" id="sonata.block.loader.chain"/>
             <argument type="service" id="sonata.block.manager"/>

--- a/Resources/doc/reference/provided_blocks.rst
+++ b/Resources/doc/reference/provided_blocks.rst
@@ -33,16 +33,15 @@ MenuBlockService
 
 This block service displays a KNP Menu.
 
-Provide a list of available menus in the configuration.
+Defining a menu could be done by inserting the ``sonata.block.menu`` tag.
 
 .. configuration-block::
 
-    .. code-block:: yaml
+    .. code-block:: xml
 
-        sonata_block:
-            menus:
-                'AppBundle:Builder:mainMenu': 'Main Menu'
-                'footer': 'Footer Menu' # Use alias name if using menus as a service
+        <service id="sonata.block.menu.main" class="Sonata\BlockBundle\Menu\MainMenu">
+            <tag name="sonata.block.menu" />
+        </service>
 
 Upon configuration, you may set some rendering options (see KNP Doc for those).
 

--- a/Tests/Block/Service/MenuBlockServiceTest.php
+++ b/Tests/Block/Service/MenuBlockServiceTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Block\Service;
+
+use Knp\Menu\Provider\MenuProviderInterface;
+use Sonata\BlockBundle\Block\Service\MenuBlockService;
+use Sonata\BlockBundle\Menu\MenuRegistryInterface;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+
+class MenuBlockServiceTest extends AbstractBlockServiceTestCase
+{
+    /**
+     * @var MenuProviderInterface
+     */
+    private $menuProvider;
+
+    /**
+     * @var MenuRegistryInterface
+     */
+    private $menuRegistry;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->menuProvider = $this->getMock('Knp\Menu\Provider\MenuProviderInterface');
+        $this->menuRegistry = $this->getMock('Sonata\BlockBundle\Menu\MenuRegistryInterface');
+    }
+
+    public function testBuildEditForm()
+    {
+        $this->menuRegistry->expects($this->once())->method('getAliasNames')
+            ->will($this->returnValue(array(
+                'acme:demobundle:menu' => 'Test Menu',
+            )));
+
+        $formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')->disableOriginalConstructor()->getMock();
+        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+
+        $choiceOptions = array(
+            'required' => false,
+        );
+
+        $choices = array(
+            'acme:demobundle:menu' => 'Test Menu',
+        );
+
+        // NEXT_MAJOR: remove SF 2.7+ BC
+        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            $choices = array_flip($choices);
+
+            // choice_as_value options is not needed in SF 3.0+
+            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
+                $choiceOptions['choices_as_values'] = true;
+            }
+        }
+
+        $choiceOptions['choices'] = $choices;
+
+        $formMapper->expects($this->once())->method('add')
+            ->with('settings', 'sonata_type_immutable_array', array(
+                'keys' => array(
+                    array('title', 'text', array('required' => false)),
+                    array('cache_policy', 'choice', array('choices' => array('public', 'private'))),
+                    array('menu_name', 'choice', $choiceOptions),
+                    array('safe_labels', 'checkbox', array('required' => false)),
+                    array('current_class', 'text', array('required' => false)),
+                    array('first_class', 'text', array('required' => false)),
+                    array('last_class', 'text', array('required' => false)),
+                    array('menu_class', 'text', array('required' => false)),
+                    array('children_class', 'text', array('required' => false)),
+                    array('menu_template', 'text', array('required' => false)),
+                ),
+            ));
+
+        $blockService = new MenuBlockService('sonata.page.block.menu', $this->templating, $this->menuProvider, $this->menuRegistry);
+        $blockService->buildEditForm($formMapper, $block);
+    }
+
+    public function testDefaultSettings()
+    {
+        $blockService = new MenuBlockService('sonata.page.block.menu', $this->templating, $this->menuProvider, $this->menuRegistry);
+        $blockContext = $this->getBlockContext($blockService);
+
+        $this->assertSettings(array(
+            'title' => 'sonata.page.block.menu',
+            'cache_policy' => 'public',
+            'template' => 'SonataBlockBundle:Block:block_core_menu.html.twig',
+            'menu_name' => '',
+            'safe_labels' => false,
+            'current_class' => 'active',
+            'first_class' => false,
+            'last_class' => false,
+            'current_uri' => null,
+            'menu_class' => 'list-group',
+            'children_class' => 'list-group-item',
+            'menu_template' => null,
+        ), $blockContext);
+    }
+}

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,11 +1,19 @@
 UPGRADE 3.x
 ===========
 
+## Menu blocks
+
+Menus for the `MenuBlockService` can now be defined by a `<tag name="sonata.block.menu"/>` tag. 
+Defining the blocks via `sonata_block.menus` is deprecated.
+
+## Inject blocks
+
 Injecting the block id into a service is deprecated and will be automatically set.
+
 
 Instead, provide an empty argument:
 
-## Before
+### Before
 ```
     <service id="acme.block.service" class="Acme\BlockBundle\AcmeBlockService">
         <tag name="sonata.block"/>
@@ -13,7 +21,7 @@ Instead, provide an empty argument:
     </service>
 ```
 
-## After
+### After
 ```
     <service id="acme.block.service" class="Acme\BlockBundle\AcmeBlockService">
         <tag name="sonata.block"/>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is BC.
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Created `MenuManager` to collect all menus for the `MenuBlockService`
- Added new `sonata.block_menu` tag

### Deprecated
- Deprecated the array parameter in `MenuBlockService`in favor of the new `MenuManager`
```
## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [x] Update the tests
- [x] Update the documentation
- [x] Add an upgrade note
## Subject

Instead of defining knp menu classes in the static configuration, you can now create new menu services by extening a the new `MenuBuilderInterface` and the new `sonata.block_menu` tag. A new `MenuManager` will hold all defined menu classes.
