### PR TITLE
Always use service id as block id

### DIFF
--- a/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -31,12 +31,27 @@ class TweakCompilerPass implements CompilerPassInterface
 
         $parameters = $container->getParameter('sonata_block.blocks');
 
-        foreach ($container->findTaggedServiceIds('sonata.block') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('sonata.block') as $id => $tags) {
+            $definition = $container->getDefinition($id);
+
+            $arguments = $definition->getArguments();
+
+            // Replace empty block id with service id
+            if (strlen($arguments[0]) == 0) {
+                $definition->replaceArgument(0, $id);
+            } elseif ($id != $arguments[0]) {
+                // NEXT_MAJOR: Remove deprecation notice
+                @trigger_error(
+                    'Using different service id and block id is deprecated since 3.x and will be removed in 4.0.',
+                    E_USER_DEPRECATED
+                );
+            }
+
             $manager->addMethodCall('add', array($id, $id, isset($parameters[$id]) ? $parameters[$id]['contexts'] : array()));
         }
 
         $services = array();
-        foreach ($container->findTaggedServiceIds('sonata.block.loader') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('sonata.block.loader') as $id => $tags) {
             $services[] = new Reference($id);
         }
 

--- a/Resources/doc/reference/your_first_block.rst
+++ b/Resources/doc/reference/your_first_block.rst
@@ -177,7 +177,7 @@ We are almost done! Now, just declare the block as a service:
 
         <service id="sonata.block.service.rss" class="Sonata\BlockBundle\Block\Service\RssBlockService">
             <tag name="sonata.block" />
-            <argument>sonata.block.service.rss</argument>
+            <argument/>
             <argument type="service" id="templating" />
         </service>
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,26 @@
 UPGRADE 3.x
 ===========
 
+Injecting the block id into a service is deprecated and will be automatically set.
+
+Instead, provide an empty argument:
+
+## Before
+```
+    <service id="acme.block.service" class="Acme\BlockBundle\AcmeBlockService">
+        <tag name="sonata.block"/>
+        <argument>acme.block.service</argument>
+    </service>
+```
+
+## After
+```
+    <service id="acme.block.service" class="Acme\BlockBundle\AcmeBlockService">
+        <tag name="sonata.block"/>
+        <argument/>
+    </service>
+```
+
 UPGRADE FROM 3.1 to 3.2
 =======================
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

This is the BC version for #302

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

``` markdown
### Changed
- empty block names are automatically set via `TweakCompilerPass`
```
### Subject

The block id is automatically set to the internal service id (if empty). This is the same mechanism like creating a admin.
