### PR TITLE
Fix documentation in demo class

### DIFF
--- a/Event/TextBlockListener.php
+++ b/Event/TextBlockListener.php
@@ -24,7 +24,7 @@ use Symfony\Component\EventDispatcher\Event;
  *     text.listener:
  *        class: Sonata\BlockBundle\Event\TextBlockListener
  *        tags:
- *          - { name: kernel.event_listener, event: 'sonata.block.event.sonata.admin.form.edit.top', method: onBlock}
+ *          - { name: kernel.event_listener, event: 'sonata.block.event.sonata.admin.edit.form.top', method: onBlock}
  */
 class TextBlockListener
 {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is documentation fix only.


## Subject

<!-- Describe your Pull Request content here -->
Improves typo in event name in TextBlockListener usage documentation. Trivial but hard to see if you copy and paste example to service to see how it works.