### PR TITLE
Update to "Your First Block" documentation.

### DIFF
--- a/Resources/doc/reference/your_first_block.rst
+++ b/Resources/doc/reference/your_first_block.rst
@@ -55,6 +55,10 @@ In the current tutorial, the default settings are:
         ));
     }
 
+.. note::
+
+    For version 3.2 of the block-bundle, you want to use the function configureSettings(OptionsResolver $resolver) { ... }.
+
 Form Editing
 ------------
 In order to allow editing forms, the ``BlockBundle`` relies on the ``AdminBundle``.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the documentation update has to do with the block-bundle version 3.2.0. I assume this bundle is available only in the 3.x branch.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added documentation about setting up your first block for version 3.2.0 of the block-bundle.
```
