### PR TITLE
Fix upgrade 3.1 to 3.2 notice

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -27,7 +27,8 @@ UPGRADE FROM 3.1 to 3.2
 ## Deprecated block classes and interfaces
 
 The `Sonata\BlockBundle\Block\AbstractBlockService` and `Sonata\BlockBundle\Block\BaseBlockService` classes are deprecated.
-Use `Sonata\BlockBundle\Block\AbstractBlockService` for normal blocks or `Sonata\BlockBundle\Block\AbstractAdminBlockService` for manageable blocks instead.
+Use `Sonata\BlockBundle\Block\Service\AbstractBlockService` for normal blocks
+or `Sonata\BlockBundle\Block\Service\AbstractAdminBlockService` for manageable blocks instead.
 
 The interfaces `Sonata\BlockBundle\Block\BlockServiceInterface` and `Sonata\BlockBundle\Block\BlockAdminServiceInterface` are deprecated.
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is a documentation fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed typo in 3.1 to 3.2 upgrade notice
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->
Change `Sonata\BlockBundle\Block` to `Sonata\BlockBundle\Block\Service` namespace in new classes upgrade notice.