### PR TITLE
Drop old versions of Symfony

### DIFF
--- a/Block/BlockContextManager.php
+++ b/Block/BlockContextManager.php
@@ -158,24 +158,12 @@ class BlockContextManager implements BlockContextManagerInterface
             'ttl' => (int) $block->getTtl(),
         ));
 
-        // TODO: Remove it when bumping requirements to SF 2.6+
-        if (method_exists($optionsResolver, 'setDefined')) {
-            $optionsResolver
-                ->addAllowedTypes('use_cache', 'bool')
-                ->addAllowedTypes('extra_cache_keys', 'array')
-                ->addAllowedTypes('attr', 'array')
-                ->addAllowedTypes('ttl', 'int')
-                ->addAllowedTypes('template', array('string', 'bool'))
-            ;
-        } else {
-            $optionsResolver->addAllowedTypes(array(
-                'use_cache' => array('bool'),
-                'extra_cache_keys' => array('array'),
-                'attr' => array('array'),
-                'ttl' => array('int'),
-                'template' => array('string', 'bool'),
-            ));
-        }
+        $optionsResolver
+            ->addAllowedTypes('use_cache', 'bool')
+            ->addAllowedTypes('extra_cache_keys', 'array')
+            ->addAllowedTypes('attr', 'array')
+            ->addAllowedTypes('ttl', 'int')
+            ->addAllowedTypes('template', array('string', 'bool'));
 
         // add type and class settings for block
         $class = ClassUtils::getClass($block);

--- a/Block/Service/MenuBlockService.php
+++ b/Block/Service/MenuBlockService.php
@@ -164,15 +164,7 @@ class MenuBlockService extends AbstractAdminBlockService
             $choices = $this->menuRegistry->getAliasNames();
         }
 
-        // NEXT_MAJOR: remove SF 2.7+ BC
-        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-
-            // choice_as_value options is not needed in SF 3.0+
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
-        }
+        $choices = array_flip($choices);
 
         $choiceOptions['choices'] = $choices;
 

--- a/Resources/views/Profiler/block.html.twig
+++ b/Resources/views/Profiler/block.html.twig
@@ -59,9 +59,6 @@
 {% endblock %}
 
 {% block panel %}
-    {# NEXT_MAJOR : remove this when Symfony Requirement will be bumped to 2.8+ #}
-    {% set profiler_markup_version = profiler_markup_version|default(1) %}
-
     <h2>Events Blocks</h2>
     <table>
         <tr>

--- a/Tests/Block/Service/MenuBlockServiceTest.php
+++ b/Tests/Block/Service/MenuBlockServiceTest.php
@@ -50,19 +50,7 @@ class MenuBlockServiceTest extends AbstractBlockServiceTestCase
             'required' => false,
         );
 
-        $choices = array(
-            'acme:demobundle:menu' => 'Test Menu',
-        );
-
-        // NEXT_MAJOR: remove SF 2.7+ BC
-        if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
-            $choices = array_flip($choices);
-
-            // choice_as_value options is not needed in SF 3.0+
-            if (method_exists('Symfony\Component\Form\FormTypeInterface', 'setDefaultOptions')) {
-                $choiceOptions['choices_as_values'] = true;
-            }
-        }
+        $choices = array('Test Menu' => 'acme:demobundle:menu');
 
         $choiceOptions['choices'] = $choices;
 

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         "doctrine/common": "^2.3",
         "sonata-project/cache": "^1.0",
         "sonata-project/core-bundle": "^3.0",
-        "symfony/form": "^2.3 || ^3.0",
-        "symfony/http-kernel": "^2.3 || ^3.0"
+        "symfony/form": "^2.8 || ^3.0",
+        "symfony/http-kernel": "^2.8 || ^3.0"
     },
     "require-dev": {
         "knplabs/knp-menu-bundle": "^2.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/admin-bundle": "^3.0 || ^4.0@dev",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^2.8 || ^3.0"
     },
     "suggest": {
         "knplabs/knp-menu-bundle": "^2.0",


### PR DESCRIPTION
I am targetting this branch, because dropping versions of symfony is considered a BC-break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- compatibility with symfony 2.3 through 2.7 was dropped
```
