### PR TITLE
Removed deprecated getMock in unit tests

### DIFF
--- a/Test/AbstractBlockServiceTestCase.php
+++ b/Test/AbstractBlockServiceTestCase.php
@@ -47,11 +47,11 @@ abstract class AbstractBlockServiceTestCase extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $this->templating = new FakeTemplating();
 
-        $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
-        $this->blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $blockLoader = $this->createMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
+        $this->blockServiceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
         $this->blockContextManager = new BlockContextManager($blockLoader, $this->blockServiceManager);
     }
 
@@ -66,7 +66,7 @@ abstract class AbstractBlockServiceTestCase extends \PHPUnit_Framework_TestCase
     {
         $this->blockServiceManager->expects($this->once())->method('get')->will($this->returnValue($blockService));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->once())->method('getSettings')->will($this->returnValue(array()));
 
         $blockContext = $this->blockContextManager->get($block);
@@ -96,5 +96,21 @@ abstract class AbstractBlockServiceTestCase extends \PHPUnit_Framework_TestCase
         ksort($blockSettings);
 
         $this->assertSame($completeExpectedOptions, $blockSettings);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method when dropping support for < PHPUnit 5.4.
+     *
+     * @param string $class
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($class)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($class);
+        }
+
+        return $this->getMock($class);
     }
 }

--- a/Tests/Block/BlockContextManagerTest.php
+++ b/Tests/Block/BlockContextManagerTest.php
@@ -13,21 +13,22 @@ namespace Sonata\BlockBundle\Tests\Block;
 
 use Doctrine\Common\Util\ClassUtils;
 use Sonata\BlockBundle\Block\BlockContextManager;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
-class BlockContextManagerTest extends \PHPUnit_Framework_TestCase
+class BlockContextManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetWithValidData()
     {
-        $service = $this->getMock('Sonata\BlockBundle\Block\AbstractBlockService');
+        $service = $this->createMock('Sonata\BlockBundle\Block\AbstractBlockService');
 
         $service->expects($this->once())->method('configureSettings');
 
-        $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
+        $blockLoader = $this->createMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
 
-        $serviceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $serviceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
         $serviceManager->expects($this->once())->method('get')->will($this->returnValue($service));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->once())->method('getSettings')->will($this->returnValue(array()));
 
         $manager = new BlockContextManager($blockLoader, $serviceManager);
@@ -47,15 +48,15 @@ class BlockContextManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetWithSettings()
     {
-        $service = $this->getMock('Sonata\BlockBundle\Block\AbstractBlockService');
+        $service = $this->createMock('Sonata\BlockBundle\Block\AbstractBlockService');
         $service->expects($this->once())->method('configureSettings');
 
-        $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
+        $blockLoader = $this->createMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
 
-        $serviceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $serviceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
         $serviceManager->expects($this->once())->method('get')->will($this->returnValue($service));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->once())->method('getSettings')->will($this->returnValue(array()));
 
         $blocksCache = array(
@@ -85,18 +86,18 @@ class BlockContextManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testWithInvalidSettings()
     {
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock('Psr\Log\LoggerInterface');
         $logger->expects($this->exactly(1))->method('error');
 
-        $service = $this->getMock('Sonata\BlockBundle\Block\AbstractBlockService');
+        $service = $this->createMock('Sonata\BlockBundle\Block\AbstractBlockService');
         $service->expects($this->exactly(2))->method('configureSettings');
 
-        $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
+        $blockLoader = $this->createMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
 
-        $serviceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $serviceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
         $serviceManager->expects($this->exactly(2))->method('get')->will($this->returnValue($service));
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->once())->method('getSettings')->will($this->returnValue(array(
             'template' => array(),
         )));
@@ -114,15 +115,15 @@ class BlockContextManagerTest extends \PHPUnit_Framework_TestCase
 //     */
 //    public function testGetWithException()
 //    {
-//        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+//        $service = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
 //        $service->expects($this->exactly(2))->method('setDefaultSettings');
 //
-//        $blockLoader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
+//        $blockLoader = $this->createMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
 //
-//        $serviceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+//        $serviceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
 //        $serviceManager->expects($this->exactly(2))->method('get')->will($this->returnValue($service));
 //
-//        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+//        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
 //        $block->expects($this->once())->method('getSettings')->will($this->returnValue(array(
 //            'template' => array()
 //        )));

--- a/Tests/Block/BlockExecutionContextTest.php
+++ b/Tests/Block/BlockExecutionContextTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\BlockBundle\Tests\Block;
 
 use Sonata\BlockBundle\Block\BlockContext;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
-class BlockExecutionContextTest extends \PHPUnit_Framework_TestCase
+class BlockExecutionContextTest extends PHPUnit_Framework_TestCase
 {
     public function testBasicFeature()
     {
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
 
         $blockContext = new BlockContext($block, array(
             'hello' => 'world',
@@ -34,7 +35,7 @@ class BlockExecutionContextTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidParameter()
     {
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
 
         $blockContext = new BlockContext($block);
 

--- a/Tests/Block/BlockLoaderChainTest.php
+++ b/Tests/Block/BlockLoaderChainTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\BlockBundle\Tests\Block;
 
 use Sonata\BlockBundle\Block\BlockLoaderChain;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
-class BlockLoaderChainTest extends \PHPUnit_Framework_TestCase
+class BlockLoaderChainTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \Sonata\BlockBundle\Exception\BlockNotFoundException
@@ -26,9 +27,9 @@ class BlockLoaderChainTest extends \PHPUnit_Framework_TestCase
 
     public function testLoaderWithSupportedLoader()
     {
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
 
-        $loader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
+        $loader = $this->createMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
         $loader->expects($this->once())->method('support')->will($this->returnValue(true));
         $loader->expects($this->once())->method('load')->will($this->returnValue($block));
 
@@ -44,7 +45,7 @@ class BlockLoaderChainTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoaderWithUnSupportedLoader()
     {
-        $loader = $this->getMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
+        $loader = $this->createMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
         $loader->expects($this->once())->method('support')->will($this->returnValue(false));
         $loader->expects($this->never())->method('load');
 

--- a/Tests/Block/BlockRendererTest.php
+++ b/Tests/Block/BlockRendererTest.php
@@ -16,11 +16,12 @@ use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Block\BlockRenderer;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Sonata\BlockBundle\Exception\Strategy\StrategyManager;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Unit test of BlockRenderer class.
  */
-class BlockRendererTest extends \PHPUnit_Framework_TestCase
+class BlockRendererTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|BlockServiceManagerInterface
@@ -47,9 +48,9 @@ class BlockRendererTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
-        $this->exceptionStrategyManager = $this->getMock('Sonata\BlockBundle\Exception\Strategy\StrategyManagerInterface');
-        $this->logger = $this->getMock('Psr\Log\LoggerInterface');
+        $this->blockServiceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $this->exceptionStrategyManager = $this->createMock('Sonata\BlockBundle\Exception\Strategy\StrategyManagerInterface');
+        $this->logger = $this->createMock('Psr\Log\LoggerInterface');
 
         $this->renderer = new BlockRenderer($this->blockServiceManager, $this->exceptionStrategyManager, $this->logger);
     }
@@ -62,14 +63,14 @@ class BlockRendererTest extends \PHPUnit_Framework_TestCase
         // GIVEN
 
         // mock a block service that returns a response
-        $response = $this->getMock('Symfony\Component\HttpFoundation\Response');
-        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $response = $this->createMock('Symfony\Component\HttpFoundation\Response');
+        $service = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
         $service->expects($this->once())->method('load');
         $service->expects($this->once())->method('execute')->will($this->returnValue($response));
         $this->blockServiceManager->expects($this->once())->method('get')->will($this->returnValue($service));
 
         // mock a block object
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $blockContext = new BlockContext($block);
 
         // WHEN
@@ -90,7 +91,7 @@ class BlockRendererTest extends \PHPUnit_Framework_TestCase
         // GIVEN
 
         // mock a block service that returns a string response
-        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $service = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
         $service->expects($this->once())->method('load');
         $service->expects($this->once())->method('execute')->will($this->returnValue('wrong response'));
 
@@ -107,7 +108,7 @@ class BlockRendererTest extends \PHPUnit_Framework_TestCase
         $this->logger->expects($this->once())->method('error');
 
         // mock a block object
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $blockContext = new BlockContext($block);
 
         // WHEN
@@ -125,10 +126,10 @@ class BlockRendererTest extends \PHPUnit_Framework_TestCase
         // GIVEN
 
         // mock a block service that throws an user exception
-        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $service = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
         $service->expects($this->once())->method('load');
 
-        $exception = $this->getMock('\Exception');
+        $exception = $this->createMock('\Exception');
         $service->expects($this->once())
             ->method('execute')
             ->will($this->returnCallback(function () use ($exception) {
@@ -138,7 +139,7 @@ class BlockRendererTest extends \PHPUnit_Framework_TestCase
         $this->blockServiceManager->expects($this->once())->method('get')->will($this->returnValue($service));
 
         // mock the exception strategy manager to return a response when given the correct exception
-        $response = $this->getMock('Symfony\Component\HttpFoundation\Response');
+        $response = $this->createMock('Symfony\Component\HttpFoundation\Response');
         $this->exceptionStrategyManager->expects($this->once())
             ->method('handleException')
             ->with($this->equalTo($exception))
@@ -148,7 +149,7 @@ class BlockRendererTest extends \PHPUnit_Framework_TestCase
         $this->logger->expects($this->once())->method('error');
 
         // mock a block object
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $blockContext = new BlockContext($block);
 
         // WHEN

--- a/Tests/Block/BlockServiceManagerTest.php
+++ b/Tests/Block/BlockServiceManagerTest.php
@@ -12,21 +12,22 @@
 namespace Sonata\BlockBundle\Tests\Block;
 
 use Sonata\BlockBundle\Block\BlockServiceManager;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
-class BlockServiceManagerTest extends \PHPUnit_Framework_TestCase
+class BlockServiceManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetBlockService()
     {
-        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $service = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())->method('get')->will($this->returnValue($service));
 
         $manager = new BlockServiceManager($container, true);
 
         $manager->add('test', 'test');
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())->method('getType')->will($this->returnValue('test'));
 
         $this->assertInstanceOf(get_class($service), $manager->get($block));
@@ -37,16 +38,16 @@ class BlockServiceManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidServiceType()
     {
-        $service = $this->getMock('stdClass');
+        $service = $this->createMock('stdClass');
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->once())->method('get')->will($this->returnValue($service));
 
         $manager = new BlockServiceManager($container, true);
 
         $manager->add('test', 'test');
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())->method('getType')->will($this->returnValue('test'));
 
         $this->assertInstanceOf(get_class($service), $manager->get($block));
@@ -57,11 +58,11 @@ class BlockServiceManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetBlockServiceException()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
         $manager = new BlockServiceManager($container, true);
 
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())->method('getType')->will($this->returnValue('fakse'));
 
         $manager->get($block);
@@ -69,10 +70,10 @@ class BlockServiceManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetEmptyListFromInvalidContext()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $manager = new BlockServiceManager($container, true);
 
-        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $service = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
 
         $manager->add('foo.bar', $service);
 
@@ -81,10 +82,10 @@ class BlockServiceManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetListFromValidContext()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $manager = new BlockServiceManager($container, true);
 
-        $service = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $service = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
 
         $manager->add('foo.bar', $service, array('fake'));
 
@@ -93,18 +94,18 @@ class BlockServiceManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testOrderServices()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $manager = new BlockServiceManager($container, true);
 
-        $serviceAbc = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $serviceAbc = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
         $serviceAbc->expects($this->any())->method('getName')->will($this->returnValue('GHI'));
         $manager->add('ghi', $serviceAbc);
 
-        $serviceAbc = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $serviceAbc = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
         $serviceAbc->expects($this->any())->method('getName')->will($this->returnValue('ABC'));
         $manager->add('abc', $serviceAbc);
 
-        $serviceAbc = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $serviceAbc = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
         $serviceAbc->expects($this->any())->method('getName')->will($this->returnValue('DEF'));
         $manager->add('def', $serviceAbc);
 

--- a/Tests/Block/Service/MenuBlockServiceTest.php
+++ b/Tests/Block/Service/MenuBlockServiceTest.php
@@ -32,8 +32,8 @@ class MenuBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->menuProvider = $this->getMock('Knp\Menu\Provider\MenuProviderInterface');
-        $this->menuRegistry = $this->getMock('Sonata\BlockBundle\Menu\MenuRegistryInterface');
+        $this->menuProvider = $this->createMock('Knp\Menu\Provider\MenuProviderInterface');
+        $this->menuRegistry = $this->createMock('Sonata\BlockBundle\Menu\MenuRegistryInterface');
     }
 
     public function testBuildEditForm()
@@ -44,7 +44,7 @@ class MenuBlockServiceTest extends AbstractBlockServiceTestCase
             )));
 
         $formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')->disableOriginalConstructor()->getMock();
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
 
         $choiceOptions = array(
             'required' => false,

--- a/Tests/Block/Service/RssBlockServiceTest.php
+++ b/Tests/Block/Service/RssBlockServiceTest.php
@@ -37,7 +37,9 @@ class RssBlockServiceTest extends AbstractBlockServiceTestCase
 
         $blockContext = new BlockContext($block, $optionResolver->resolve());
 
-        $formMapper = $this->getMock('Sonata\\AdminBundle\\Form\\FormMapper', array(), array(), '', false);
+        $formMapper = $this->getMockBuilder('Sonata\\AdminBundle\\Form\\FormMapper')
+            ->disableOriginalConstructor()
+            ->getMock();
         $formMapper->expects($this->exactly(2))->method('add');
 
         $service->buildCreateForm($formMapper, $block);

--- a/Tests/Block/Service/TextBlockServiceTest.php
+++ b/Tests/Block/Service/TextBlockServiceTest.php
@@ -34,7 +34,9 @@ class TextBlockServiceTest extends AbstractBlockServiceTestCase
 
         $blockContext = new BlockContext($block, $optionResolver->resolve($block->getSettings()));
 
-        $formMapper = $this->getMock('Sonata\\AdminBundle\\Form\\FormMapper', array(), array(), '', false);
+        $formMapper = $this->getMockBuilder('Sonata\\AdminBundle\\Form\\FormMapper')
+            ->disableOriginalConstructor()
+            ->getMock();
         $formMapper->expects($this->exactly(2))->method('add');
 
         $service->buildCreateForm($formMapper, $block);

--- a/Tests/Event/BlockEventTest.php
+++ b/Tests/Event/BlockEventTest.php
@@ -13,7 +13,7 @@ namespace Sonata\BlockBundle\Tests;
 
 use Sonata\BlockBundle\Event\BlockEvent;
 
-class BlockEventTest extends \PHPUnit_Framework_TestCase
+class BlockEventTest extends PHPUnit_Framework_TestCase
 {
     public function testBlockEvent()
     {
@@ -21,11 +21,11 @@ class BlockEventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEmpty($blockEvent->getSettings());
 
-        $blockEvent->addBlock($this->getMock('Sonata\BlockBundle\Model\BlockInterface'));
+        $blockEvent->addBlock($this->createMock('Sonata\BlockBundle\Model\BlockInterface'));
 
         $this->assertCount(1, $blockEvent->getBlocks());
 
-        $blockEvent->addBlock($this->getMock('Sonata\BlockBundle\Model\BlockInterface'));
+        $blockEvent->addBlock($this->createMock('Sonata\BlockBundle\Model\BlockInterface'));
         $this->assertCount(2, $blockEvent->getBlocks());
 
         $this->assertNull($blockEvent->getSetting('fake'));

--- a/Tests/Event/TextBlockListenerTest.php
+++ b/Tests/Event/TextBlockListenerTest.php
@@ -14,7 +14,7 @@ namespace Sonata\BlockBundle\Tests;
 use Sonata\BlockBundle\Event\BlockEvent;
 use Sonata\BlockBundle\Event\TextBlockListener;
 
-class TextBlockListenerTest extends \PHPUnit_Framework_TestCase
+class TextBlockListenerTest extends PHPUnit_Framework_TestCase
 {
     public function testEvent()
     {
@@ -32,7 +32,7 @@ class TextBlockListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testEventWithAdmin()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('getSubject');
         $admin->expects($this->once())->method('toString')->will($this->returnValue('fake object'));
 

--- a/Tests/Exception/Filter/DebugOnlyFilterTest.php
+++ b/Tests/Exception/Filter/DebugOnlyFilterTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\BlockBundle\Tests\Exception\Renderer;
 
 use Sonata\BlockBundle\Exception\Filter\DebugOnlyFilter;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Test the debug only exception filter.
  *
  * @author Olivier Paradis <paradis.olivier@gmail.com>
  */
-class DebugOnlyFilterTest extends \PHPUnit_Framework_TestCase
+class DebugOnlyFilterTest extends PHPUnit_Framework_TestCase
 {
     /**
      * test the filter with debug enabled.
@@ -26,8 +27,8 @@ class DebugOnlyFilterTest extends \PHPUnit_Framework_TestCase
     public function testWithDebugEnabled()
     {
         // GIVEN
-        $exception = $this->getMock('\Exception');
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $exception = $this->createMock('\Exception');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $filter = new DebugOnlyFilter(true);
 
         // WHEN
@@ -43,8 +44,8 @@ class DebugOnlyFilterTest extends \PHPUnit_Framework_TestCase
     public function testWithDebugDisabled()
     {
         // GIVEN
-        $exception = $this->getMock('\Exception');
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $exception = $this->createMock('\Exception');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $filter = new DebugOnlyFilter(false);
 
         // WHEN

--- a/Tests/Exception/Filter/IgnoreClassFilterTest.php
+++ b/Tests/Exception/Filter/IgnoreClassFilterTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\BlockBundle\Tests\Exception\Renderer;
 
 use Sonata\BlockBundle\Exception\Filter\IgnoreClassFilter;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Test the ignore class exception filter.
  *
  * @author Olivier Paradis <paradis.olivier@gmail.com>
  */
-class IgnoreClassFilterTest extends \PHPUnit_Framework_TestCase
+class IgnoreClassFilterTest extends PHPUnit_Framework_TestCase
 {
     /**
      * test the filter with a inherited exception.
@@ -26,8 +27,8 @@ class IgnoreClassFilterTest extends \PHPUnit_Framework_TestCase
     public function testWithInheritedException()
     {
         // GIVEN
-        $exception = $this->getMock('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $exception = $this->createMock('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $filter = new IgnoreClassFilter('\RuntimeException');
 
         // WHEN
@@ -43,8 +44,8 @@ class IgnoreClassFilterTest extends \PHPUnit_Framework_TestCase
     public function testWithNonInheritedException()
     {
         // GIVEN
-        $exception = $this->getMock('\Exception');
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $exception = $this->createMock('\Exception');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $filter = new IgnoreClassFilter('\RuntimeException');
 
         // WHEN

--- a/Tests/Exception/Filter/KeepAllFilterTest.php
+++ b/Tests/Exception/Filter/KeepAllFilterTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\BlockBundle\Tests\Exception\Renderer;
 
 use Sonata\BlockBundle\Exception\Filter\KeepAllFilter;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Test the keep all exception filter.
  *
  * @author Olivier Paradis <paradis.olivier@gmail.com>
  */
-class KeepAllFilterTest extends \PHPUnit_Framework_TestCase
+class KeepAllFilterTest extends PHPUnit_Framework_TestCase
 {
     /**
      * test the filter with an exception.
@@ -30,7 +31,7 @@ class KeepAllFilterTest extends \PHPUnit_Framework_TestCase
     public function testFilter(\Exception $exception)
     {
         // GIVEN
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $filter = new KeepAllFilter();
 
         // WHEN
@@ -48,8 +49,8 @@ class KeepAllFilterTest extends \PHPUnit_Framework_TestCase
     public function getExceptions()
     {
         return array(
-            array($this->getMock('\Exception')),
-            array($this->getMock('\RuntimeException')),
+            array($this->createMock('\Exception')),
+            array($this->createMock('\RuntimeException')),
         );
     }
 }

--- a/Tests/Exception/Filter/KeepNoneFilterTest.php
+++ b/Tests/Exception/Filter/KeepNoneFilterTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\BlockBundle\Tests\Exception\Renderer;
 
 use Sonata\BlockBundle\Exception\Filter\KeepNoneFilter;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Test the keep all exception filter.
  *
  * @author Olivier Paradis <paradis.olivier@gmail.com>
  */
-class KeepNoneFilterTest extends \PHPUnit_Framework_TestCase
+class KeepNoneFilterTest extends PHPUnit_Framework_TestCase
 {
     /**
      * test the filter with an exception.
@@ -30,7 +31,7 @@ class KeepNoneFilterTest extends \PHPUnit_Framework_TestCase
     public function testFilter(\Exception $exception)
     {
         // GIVEN
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $filter = new KeepNoneFilter();
 
         // WHEN
@@ -48,8 +49,8 @@ class KeepNoneFilterTest extends \PHPUnit_Framework_TestCase
     public function getExceptions()
     {
         return array(
-            array($this->getMock('\Exception')),
-            array($this->getMock('\RuntimeException')),
+            array($this->createMock('\Exception')),
+            array($this->createMock('\RuntimeException')),
         );
     }
 }

--- a/Tests/Exception/Renderer/InlineDebugRendererTest.php
+++ b/Tests/Exception/Renderer/InlineDebugRendererTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\BlockBundle\Tests\Exception\Renderer;
 
 use Sonata\BlockBundle\Exception\Renderer\InlineDebugRenderer;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Test the inline debug exception renderer.
  *
  * @author Olivier Paradis <paradis.olivier@gmail.com>
  */
-class InlineDebugRendererTest extends \PHPUnit_Framework_TestCase
+class InlineDebugRendererTest extends PHPUnit_Framework_TestCase
 {
     /**
      * test the renderer without debug mode.
@@ -28,9 +29,9 @@ class InlineDebugRendererTest extends \PHPUnit_Framework_TestCase
         // GIVEN
         $template = 'test-template';
         $debug = false;
-        $exception = $this->getMock('\Exception');
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
-        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $exception = $this->createMock('\Exception');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
+        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
 
         $renderer = new InlineDebugRenderer($templating, $template, $debug);
 
@@ -52,13 +53,13 @@ class InlineDebugRendererTest extends \PHPUnit_Framework_TestCase
         $debug = true;
 
         // mock an exception to render
-        $exception = $this->getMock('\Exception');
+        $exception = $this->createMock('\Exception');
 
         // mock a block instance that provoked the exception
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
 
         // mock the templating render() to return an html result
-        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
         $templating->expects($this->once())
             ->method('render')
             ->with(

--- a/Tests/Exception/Renderer/InlineRendererTest.php
+++ b/Tests/Exception/Renderer/InlineRendererTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\BlockBundle\Tests\Exception\Renderer;
 
 use Sonata\BlockBundle\Exception\Renderer\InlineRenderer;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Test the inline exception renderer.
  *
  * @author Olivier Paradis <paradis.olivier@gmail.com>
  */
-class InlineRendererTest extends \PHPUnit_Framework_TestCase
+class InlineRendererTest extends PHPUnit_Framework_TestCase
 {
     /**
      * test the render() method.
@@ -29,13 +30,13 @@ class InlineRendererTest extends \PHPUnit_Framework_TestCase
         $template = 'test-template';
 
         // mock an exception to render
-        $exception = $this->getMock('\Exception');
+        $exception = $this->createMock('\Exception');
 
         // mock a block instance that provoked the exception
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
 
         // mock the templating render() to return an html result
-        $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $templating = $this->createMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
         $templating->expects($this->once())
             ->method('render')
             ->with(

--- a/Tests/Exception/Renderer/MonkeyThrowRendererTest.php
+++ b/Tests/Exception/Renderer/MonkeyThrowRendererTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\BlockBundle\Tests\Exception\Renderer;
 
 use Sonata\BlockBundle\Exception\Renderer\MonkeyThrowRenderer;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Test the monkey throw exception renderer.
  *
  * @author Olivier Paradis <paradis.olivier@gmail.com>
  */
-class MonkeyThrowRendererTest extends \PHPUnit_Framework_TestCase
+class MonkeyThrowRendererTest extends PHPUnit_Framework_TestCase
 {
     /**
      * test the render() method with a standard Exception.
@@ -29,7 +30,7 @@ class MonkeyThrowRendererTest extends \PHPUnit_Framework_TestCase
     {
         // GIVEN
         $exception = new \Exception();
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $renderer = new MonkeyThrowRenderer();
 
         // WHEN
@@ -48,7 +49,7 @@ class MonkeyThrowRendererTest extends \PHPUnit_Framework_TestCase
     {
         // GIVEN
         $exception = new \RuntimeException();
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $renderer = new MonkeyThrowRenderer();
 
         // WHEN

--- a/Tests/Exception/Strategy/StrategyManagerTest.php
+++ b/Tests/Exception/Strategy/StrategyManagerTest.php
@@ -14,6 +14,7 @@ namespace Sonata\BlockBundle\Tests\Exception\Strategy;
 use Sonata\BlockBundle\Exception\Filter\FilterInterface;
 use Sonata\BlockBundle\Exception\Renderer\RendererInterface;
 use Sonata\BlockBundle\Exception\Strategy\StrategyManager;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -21,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @author Olivier Paradis <paradis.olivier@gmail.com>
  */
-class StrategyManagerTest extends \PHPUnit_Framework_TestCase
+class StrategyManagerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var StrategyManager
@@ -78,10 +79,10 @@ class StrategyManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->renderer1 = $this->getMock('\Sonata\BlockBundle\Exception\Renderer\RendererInterface');
-        $this->renderer2 = $this->getMock('\Sonata\BlockBundle\Exception\Renderer\RendererInterface');
-        $this->filter1 = $this->getMock('\Sonata\BlockBundle\Exception\Filter\FilterInterface');
-        $this->filter2 = $this->getMock('\Sonata\BlockBundle\Exception\Filter\FilterInterface');
+        $this->renderer1 = $this->createMock('\Sonata\BlockBundle\Exception\Renderer\RendererInterface');
+        $this->renderer2 = $this->createMock('\Sonata\BlockBundle\Exception\Renderer\RendererInterface');
+        $this->filter1 = $this->createMock('\Sonata\BlockBundle\Exception\Filter\FilterInterface');
+        $this->filter2 = $this->createMock('\Sonata\BlockBundle\Exception\Filter\FilterInterface');
 
         // setup a mock container which contains our mock renderers and filters
         $this->container = $this->getMockContainer(array(
@@ -226,7 +227,7 @@ class StrategyManagerTest extends \PHPUnit_Framework_TestCase
      */
     protected function getMockBlock($type)
     {
-        $block = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block->expects($this->any())->method('getType')->will($this->returnValue($type));
 
         return $block;
@@ -246,7 +247,7 @@ class StrategyManagerTest extends \PHPUnit_Framework_TestCase
             $map[] = array($name, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $service);
         }
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->any())->method('get')->will($this->returnValueMap($map));
 
         return $container;

--- a/Tests/Form/Type/ServiceListTypeTest.php
+++ b/Tests/Form/Type/ServiceListTypeTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\BlockBundle\Tests\Form\Type;
 
 use Sonata\BlockBundle\Form\Type\ServiceListType;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class ServiceListTypeTest extends \PHPUnit_Framework_TestCase
+class ServiceListTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFormType()
     {
-        $blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $blockServiceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
 
         $type = new ServiceListType($blockServiceManager);
 
@@ -31,7 +32,7 @@ class ServiceListTypeTest extends \PHPUnit_Framework_TestCase
      */
     public function testOptionsWithInvalidContext()
     {
-        $blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $blockServiceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
 
         $type = new ServiceListType($blockServiceManager);
 
@@ -48,10 +49,10 @@ class ServiceListTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testOptionWithValidContext()
     {
-        $blockService = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $blockService = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
         $blockService->expects($this->once())->method('getName')->will($this->returnValue('value'));
 
-        $blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $blockServiceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
         $blockServiceManager
             ->expects($this->once())
             ->method('getServicesByContext')

--- a/Tests/PHPUnit_Framework_TestCase.php
+++ b/Tests/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests;
+
+/**
+ * NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @internal
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $class
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($class)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($class);
+        }
+
+        return $this->getMock($class);
+    }
+}

--- a/Tests/Templating/Helper/BlockHelperTest.php
+++ b/Tests/Templating/Helper/BlockHelperTest.php
@@ -16,16 +16,17 @@ use Sonata\BlockBundle\Event\BlockEvent;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Templating\Helper\BlockHelper;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class BlockHelperTest extends \PHPUnit_Framework_TestCase
+class BlockHelperTest extends PHPUnit_Framework_TestCase
 {
     public function testRenderEventWithNoListener()
     {
-        $blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
-        $blockRenderer = $this->getMock('Sonata\BlockBundle\Block\BlockRendererInterface');
-        $blockContextManager = $this->getMock('Sonata\BlockBundle\Block\BlockContextManagerInterface');
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $blockServiceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $blockRenderer = $this->createMock('Sonata\BlockBundle\Block\BlockRendererInterface');
+        $blockContextManager = $this->createMock('Sonata\BlockBundle\Block\BlockContextManagerInterface');
+        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $eventDispatcher->expects($this->once())->method('dispatch')->will($this->returnCallback(function ($name, BlockEvent $event) {
             return $event;
         }));
@@ -37,7 +38,7 @@ class BlockHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testRenderEventWithListeners()
     {
-        $blockService = $this->getMock('Sonata\BlockBundle\Block\BlockServiceInterface');
+        $blockService = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');
         $blockService->expects($this->once())->method('getJavascripts')->will($this->returnValue(array(
             '/js/base.js',
         )));
@@ -45,20 +46,20 @@ class BlockHelperTest extends \PHPUnit_Framework_TestCase
             '/css/base.css',
         )));
 
-        $blockServiceManager = $this->getMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
+        $blockServiceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
         $blockServiceManager->expects($this->any())->method('get')->will($this->returnValue($blockService));
 
-        $blockRenderer = $this->getMock('Sonata\BlockBundle\Block\BlockRendererInterface');
+        $blockRenderer = $this->createMock('Sonata\BlockBundle\Block\BlockRendererInterface');
         $blockRenderer->expects($this->once())->method('render')->will($this->returnValue(new Response('<span>test</span>')));
 
-        $blockContextManager = $this->getMock('Sonata\BlockBundle\Block\BlockContextManagerInterface');
+        $blockContextManager = $this->createMock('Sonata\BlockBundle\Block\BlockContextManagerInterface');
         $blockContextManager->expects($this->once())->method('get')->will($this->returnCallback(function (BlockInterface $block) {
             $context = new BlockContext($block, $block->getSettings());
 
             return $context;
         }));
 
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $eventDispatcher->expects($this->once())->method('dispatch')->will($this->returnCallback(function ($name, BlockEvent $event) {
             $block = new Block();
             $block->setId(1);

--- a/Tests/Twig/Extension/BlockExtensionTest.php
+++ b/Tests/Twig/Extension/BlockExtensionTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\BlockBundle\Twig\Extension;
 
 use Sonata\BlockBundle\Templating\Helper\BlockHelper;
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 
-class BlockExtensionTest extends \PHPUnit_Framework_TestCase
+class BlockExtensionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|BlockHelper
@@ -36,7 +37,7 @@ class BlockExtensionTest extends \PHPUnit_Framework_TestCase
             'Sonata\BlockBundle\Templating\Helper\BlockHelper'
         )->disableOriginalConstructor()->getMock();
 
-        $loader = $this->getMock('Twig_LoaderInterface');
+        $loader = $this->createMock('Twig_LoaderInterface');
 
         $this->blockExtension = new BlockExtension($this->blockHelper);
 

--- a/Tests/Util/RecursiveBlockIteratorIteratorTest.php
+++ b/Tests/Util/RecursiveBlockIteratorIteratorTest.php
@@ -11,21 +11,22 @@
 
 namespace Sonata\BlockBundle\Tests\Entity;
 
+use Sonata\BlockBundle\Tests\PHPUnit_Framework_TestCase;
 use Sonata\BlockBundle\Util\RecursiveBlockIteratorIterator;
 
-class RecursiveBlockIteratorIteratorTest extends \PHPUnit_Framework_TestCase
+class RecursiveBlockIteratorIteratorTest extends PHPUnit_Framework_TestCase
 {
     public function testInterface()
     {
-        $block2 = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block2 = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block2->expects($this->any())->method('getType')->will($this->returnValue('block2'));
         $block2->expects($this->once())->method('hasChildren')->will($this->returnValue(false));
 
-        $block3 = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block3 = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block3->expects($this->any())->method('getType')->will($this->returnValue('block3'));
         $block3->expects($this->once())->method('hasChildren')->will($this->returnValue(false));
 
-        $block1 = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block1 = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block1->expects($this->any())->method('getType')->will($this->returnValue('block1'));
         $block1->expects($this->once())->method('hasChildren')->will($this->returnValue(true));
         $block1->expects($this->any())->method('getChildren')->will($this->returnValue(array(
@@ -33,7 +34,7 @@ class RecursiveBlockIteratorIteratorTest extends \PHPUnit_Framework_TestCase
             $block3,
         )));
 
-        $block4 = $this->getMock('Sonata\BlockBundle\Model\BlockInterface');
+        $block4 = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
         $block4->expects($this->any())->method('getType')->will($this->returnValue('block4'));
         $block4->expects($this->any())->method('hasChildren')->will($this->returnValue(false));
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is for tests only.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - `AbstractBlockServiceTestCase` uses `createMock` method
```

## Subject

The method `getMock` is deprecated.
