### PR TITLE
Avoid long lines

### DIFF
--- a/Block/AbstractBlockService.php
+++ b/Block/AbstractBlockService.php
@@ -19,8 +19,6 @@ namespace Sonata\BlockBundle\Block;
 );
 
 /**
- * Class AbstractBlockService.
- *
  * NEXT_MAJOR: remove this class.
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>

--- a/Block/BlockContextManager.php
+++ b/Block/BlockContextManager.php
@@ -18,9 +18,6 @@ use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-/**
- * Class BlockContextManager.
- */
 class BlockContextManager implements BlockContextManagerInterface
 {
     /**

--- a/Block/BlockContextManager.php
+++ b/Block/BlockContextManager.php
@@ -166,7 +166,11 @@ class BlockContextManager implements BlockContextManagerInterface
     protected function setDefaultSettings(OptionsResolverInterface $optionsResolver, BlockInterface $block)
     {
         if (get_called_class() !== __CLASS__) {
-            @trigger_error('The '.__METHOD__.' is deprecated since version 2.3, to be renamed in 4.0. Use '.__CLASS__.'::configureSettings instead.', E_USER_DEPRECATED);
+            @trigger_error(
+                'The '.__METHOD__.' is deprecated since version 2.3, to be renamed in 4.0.'
+                .' Use '.__CLASS__.'::configureSettings instead.',
+                E_USER_DEPRECATED
+            );
         }
         $this->configureSettings($optionsResolver, $block);
     }
@@ -291,7 +295,12 @@ class BlockContextManager implements BlockContextManagerInterface
         }
 
         if ($this->reflectionCache[$serviceClass]['isOldOverwritten'] && !$this->reflectionCache[$serviceClass]['isNewOverwritten']) {
-            @trigger_error('The Sonata\BlockBundle\Block\BlockServiceInterface::setDefaultSettings() method is deprecated since version 2.3 and will be removed in 4.0. Use configureSettings() instead. This method will be added to the BlockServiceInterface with SonataBlockBundle 4.0.', E_USER_DEPRECATED);
+            @trigger_error(
+                'The Sonata\BlockBundle\Block\BlockServiceInterface::setDefaultSettings() method is deprecated'
+                .' since version 2.3 and will be removed in 4.0. Use configureSettings() instead.'
+                .' This method will be added to the BlockServiceInterface with SonataBlockBundle 4.0.',
+                E_USER_DEPRECATED
+            );
         }
 
         return $optionsResolver->resolve($settings);

--- a/Block/BlockRenderer.php
+++ b/Block/BlockRenderer.php
@@ -53,8 +53,6 @@ class BlockRenderer implements BlockRendererInterface
     private $lastResponse;
 
     /**
-     * Constructor.
-     *
      * @param BlockServiceManagerInterface $blockServiceManager      Block service manager
      * @param StrategyManagerInterface     $exceptionStrategyManager Exception strategy manager
      * @param LoggerInterface              $logger                   Logger class

--- a/Block/Service/MenuBlockService.php
+++ b/Block/Service/MenuBlockService.php
@@ -24,9 +24,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Class MenuBlockService.
- *
- *
  * @author Hugo Briand <briand@ekino.com>
  */
 class MenuBlockService extends AbstractAdminBlockService
@@ -51,8 +48,6 @@ class MenuBlockService extends AbstractAdminBlockService
     protected $menuRegistry;
 
     /**
-     * Constructor.
-     *
      * @param string                      $name
      * @param EngineInterface             $templating
      * @param MenuProviderInterface       $menuProvider

--- a/Exception/Filter/DebugOnlyFilter.php
+++ b/Exception/Filter/DebugOnlyFilter.php
@@ -26,8 +26,6 @@ class DebugOnlyFilter implements FilterInterface
     protected $debug;
 
     /**
-     * Constructor.
-     *
      * @param bool $debug
      */
     public function __construct($debug)

--- a/Exception/Filter/IgnoreClassFilter.php
+++ b/Exception/Filter/IgnoreClassFilter.php
@@ -27,8 +27,6 @@ class IgnoreClassFilter implements FilterInterface
     protected $class;
 
     /**
-     * Constructor.
-     *
      * @param string $class
      */
     public function __construct($class)

--- a/Exception/Renderer/InlineDebugRenderer.php
+++ b/Exception/Renderer/InlineDebugRenderer.php
@@ -44,8 +44,6 @@ class InlineDebugRenderer implements RendererInterface
     protected $debug;
 
     /**
-     * Constructor.
-     *
      * @param EngineInterface $templating Templating engine
      * @param string          $template   Template to render
      * @param bool            $debug      Whether the debug is enabled or not

--- a/Exception/Renderer/InlineRenderer.php
+++ b/Exception/Renderer/InlineRenderer.php
@@ -33,8 +33,6 @@ class InlineRenderer implements RendererInterface
     protected $template;
 
     /**
-     * Constructor.
-     *
      * @param EngineInterface $templating Templating engine
      * @param string          $template   Template to render
      */

--- a/Exception/Strategy/StrategyManager.php
+++ b/Exception/Strategy/StrategyManager.php
@@ -61,8 +61,6 @@ class StrategyManager implements StrategyManagerInterface
     protected $defaultRenderer;
 
     /**
-     * Constructor.
-     *
      * @param ContainerInterface $container      Dependency injection container
      * @param array              $filters        Filter definitions
      * @param array              $renderers      Renderer definitions

--- a/Form/Type/ContainerTemplateType.php
+++ b/Form/Type/ContainerTemplateType.php
@@ -16,9 +16,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * Class ContainerTemplateType.
- *
- *
  * @author Hugo Briand <briand@ekino.com>
  */
 class ContainerTemplateType extends AbstractType

--- a/Model/BaseBlock.php
+++ b/Model/BaseBlock.php
@@ -66,9 +66,6 @@ abstract class BaseBlock implements BlockInterface
      */
     protected $ttl;
 
-    /**
-     * Constructor.
-     */
     public function __construct()
     {
         $this->settings = array();

--- a/Profiler/DataCollector/BlockDataCollector.php
+++ b/Profiler/DataCollector/BlockDataCollector.php
@@ -54,8 +54,6 @@ class BlockDataCollector implements DataCollectorInterface, \Serializable
     protected $events = array();
 
     /**
-     * Constructor.
-     *
      * @param BlockHelper $blockHelper    Block renderer
      * @param array       $containerTypes array of container types
      */

--- a/Util/OptionsResolver.php
+++ b/Util/OptionsResolver.php
@@ -13,9 +13,6 @@ namespace Sonata\BlockBundle\Util;
 
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
-/**
- * Class OptionsResolver.
- */
 class OptionsResolver extends \Symfony\Component\OptionsResolver\OptionsResolver implements OptionsResolverInterface
 {
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->

Some cleanup

## Temp

```php
@trigger_error(
    'The Sonata\BlockBundle\Block\BlockServiceInterface::setDefaultSettings() method is deprecated'
    .' since version 2.3 and will be removed in 4.0. Use configureSettings() instead.'
    .' This method will be added to the BlockServiceInterface with SonataBlockBundle 4.0.',
    E_USER_DEPRECATED
);
```