### PR TITLE
Remove undefined block

### DIFF
--- a/Resources/views/Profiler/block.html.twig
+++ b/Resources/views/Profiler/block.html.twig
@@ -113,7 +113,6 @@
         </div>
     {% endif %}
 
-    {{ block('javascript') }}
 {% endblock %}
 
 {% block table %}


### PR DESCRIPTION
This seems like a careless mistake. Old versions of Twig allow calling
an undefined block, which explains how this was not caught.
Fixes #361

I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Profiler block Twig 2.0 compatibility
```

## To do

- [ ] Test the fix. @uLow, can you do that for us?
