### PR TITLE
improve deprecation notice

### DIFF
--- a/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -43,7 +43,7 @@ class TweakCompilerPass implements CompilerPassInterface
             } elseif ($id != $arguments[0]) {
                 // NEXT_MAJOR: Remove deprecation notice
                 @trigger_error(
-                    'Using different service id and block id is deprecated since 3.x and will be removed in 4.0.',
+                    sprintf('Using service id %s different from block id %s is deprecated since 3.x and will be removed in 4.0.', $id, $arguments[0]),
                     E_USER_DEPRECATED
                 );
             }


### PR DESCRIPTION
I am targetting this branch, because the deprecation notice is in the 3.x branch.

## Subject

It is really hard to know what is wrong when the deprecation message just says "Using different service id and block id is deprecated". Even when looking at a stack trace, we only see that it happens during symfony building the container, but not where it happened. With the id's it becomes trivial to find the place were the mistake happens.

I did not add a changelog because this fix on the deprecation notice seems not something that should appear in the changelog.

(Btw, i stumbled upon this while investigating deprecations - turns out the problem is within the block bundle itself. It would be nice if we could supress the deprecation notice in that case - i assume its not changed to preserve BC. we could also possibly move the services and create an alias from the old service. Unless somebody did a compiler pass to change the service definition...)