### PR TITLE
avoid triggering our own deprecation notice

### DIFF
--- a/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -40,7 +40,7 @@ class TweakCompilerPass implements CompilerPassInterface
             // Replace empty block id with service id
             if (strlen($arguments[0]) == 0) {
                 $definition->replaceArgument(0, $id);
-            } elseif ($id != $arguments[0]) {
+            } elseif ($id != $arguments[0] && 0 !== strpos('Sonata\\BlockBundle\\Block\\Service\\', $definition->getClass())) {
                 // NEXT_MAJOR: Remove deprecation notice
                 @trigger_error(
                     'Using different service id and block id is deprecated since 3.x and will be removed in 4.0.',


### PR DESCRIPTION
I am targetting this branch, because the problem is with this branch.

Closes #363 

## Subject

Do not throw deprecation notices for code that is in this bundle (and will only be fixed for version 4).

## Changelog

```markdown
# Fixed
- Some unwanted deprecation notices about code we can't change until next major version have been removed
```