### PR TITLE
Resolve definition class parameter first

### DIFF
--- a/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -40,7 +40,10 @@ class TweakCompilerPass implements CompilerPassInterface
             // Replace empty block id with service id
             if (strlen($arguments[0]) == 0) {
                 $definition->replaceArgument(0, $id);
-            } elseif ($id != $arguments[0] && 0 !== strpos('Sonata\\BlockBundle\\Block\\Service\\', $definition->getClass())) {
+            } elseif ($id != $arguments[0] && 0 !== strpos(
+                'Sonata\\BlockBundle\\Block\\Service\\',
+                $container->getParameterBag()->resolveValue($definition->getClass())
+            )) {
                 // NEXT_MAJOR: Remove deprecation notice
                 @trigger_error(
                     sprintf('Using service id %s different from block id %s is deprecated since 3.x and will be removed in 4.0.', $id, $arguments[0]),


### PR DESCRIPTION
I am targeting this branch, because it's a BC fix.

Refs https://github.com/sonata-project/SonataBlockBundle/pull/367#issuecomment-286097135

## Changelog

```markdown
### Fixed
Resolve container parameters before comparing class names
```