### PR TITLE
Finally fix internal deprecations

### DIFF
--- a/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -41,8 +41,8 @@ class TweakCompilerPass implements CompilerPassInterface
             if (strlen($arguments[0]) == 0) {
                 $definition->replaceArgument(0, $id);
             } elseif ($id != $arguments[0] && 0 !== strpos(
-                'Sonata\\BlockBundle\\Block\\Service\\',
-                $container->getParameterBag()->resolveValue($definition->getClass())
+                $container->getParameterBag()->resolveValue($definition->getClass()),
+                'Sonata\\BlockBundle\\Block\\Service\\'
             )) {
                 // NEXT_MAJOR: Remove deprecation notice
                 @trigger_error(


### PR DESCRIPTION
I am targeting this branch, because #367 and #369 still don't fix #363.

Closes #363 #367 #369

## Changelog
```markdown
### Fixed
- Internal deprecations finally fixed
```

## Subject

@pkruithof and @dbu mixed up the order of arguments in his PR, that happens