### PR TITLE
use configureOptions instead of setDefaultOptions in doc

### DIFF
--- a/Resources/doc/reference/your_first_block.rst
+++ b/Resources/doc/reference/your_first_block.rst
@@ -35,7 +35,7 @@ The current RSS block will extend this base class. The other `use` statements ar
 Default settings
 ----------------
 
-A `block service` needs settings to work properly, so to ensure consistency, the service should define a ``setDefaultSettings`` method.
+A `block service` needs settings to work properly, so to ensure consistency, the service should define a ``configureOptions`` method.
 In the current tutorial, the default settings are:
 
 * `URL`: the feed url,
@@ -46,7 +46,7 @@ In the current tutorial, the default settings are:
 
     <?php
 
-    public function setDefaultSettings(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'url'      => false,

--- a/Resources/doc/reference/your_first_block.rst
+++ b/Resources/doc/reference/your_first_block.rst
@@ -75,7 +75,7 @@ In order to allow editing forms, the ``BlockBundle`` relies on the ``AdminBundle
         ;
     }
 
-The validation is done at runtime through a ``validateBlock`` method. You can call any Symfony2 assertions, like:
+The validation is done at runtime through a ``validateBlock`` method. You can call any Symfony assertions, like:
 
 .. code-block:: php
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a docs change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rework of #348 

## Subject

use configureOptions instead of setDefaultOptions in doc
