### PR TITLE
prevent notice if $arguments is an empty array

### DIFF
--- a/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -38,7 +38,7 @@ class TweakCompilerPass implements CompilerPassInterface
             $arguments = $definition->getArguments();
 
             // Replace empty block id with service id
-            if (strlen($arguments[0]) == 0) {
+            if (empty($arguments) || strlen($arguments[0]) == 0) {
                 $definition->replaceArgument(0, $id);
             } elseif ($id != $arguments[0] && 0 !== strpos(
                 $container->getParameterBag()->resolveValue($definition->getClass()),


### PR DESCRIPTION
I am targeting this branch, because this error was introduced in the 3.3 version.

Closes #374

## Subject

if services are defined through annotations the arguments are modified later -> therefore the $arguments variable is an empty array at this point. which in return causes the error if [0] is accessed

## Changelog

```markdown
# Fixed
- a notice that appeared when defining services through annotations
```