### PR TITLE
check if menuRegistry is not empty in MenuBlockService

### DIFF
--- a/Block/Service/MenuBlockService.php
+++ b/Block/Service/MenuBlockService.php
@@ -156,7 +156,7 @@ class MenuBlockService extends AbstractAdminBlockService
         $choices = $this->menus;
 
         if (count($choices) == 0) {
-            if(!empty($this->menuRegistry)){
+            if (!empty($this->menuRegistry)) {
                 $choices = $this->menuRegistry->getAliasNames();
             }
         }

--- a/Block/Service/MenuBlockService.php
+++ b/Block/Service/MenuBlockService.php
@@ -156,7 +156,9 @@ class MenuBlockService extends AbstractAdminBlockService
         $choices = $this->menus;
 
         if (count($choices) == 0) {
-            $choices = $this->menuRegistry->getAliasNames();
+            if(!empty($this->menuRegistry)){
+                $choices = $this->menuRegistry->getAliasNames();
+            }
         }
 
         // NEXT_MAJOR: remove SF 2.7+ BC


### PR DESCRIPTION
I am targeting this branch, because `sonata.page.block.breadcrumb` don't work

Closes #381

## Changelog

```markdown

### Fixed
- empty menuRegistry in ``MenuBlockService``

```



