### PR TITLE
Bugfix: Reordered if statements in BlockHelper

### DIFF
--- a/Templating/Helper/BlockHelper.php
+++ b/Templating/Helper/BlockHelper.php
@@ -431,12 +431,12 @@ class BlockHelper extends Helper
         $results = array();
 
         foreach ($this->eventDispatcher->getListeners($eventName) as $listener) {
-            if (is_object($listener[0])) {
+            if ($listener instanceof \Closure) {
+                $results[] = '{closure}()';
+            } elseif (is_object($listener[0])) {
                 $results[] = get_class($listener[0]);
             } elseif (is_string($listener[0])) {
                 $results[] = $listener[0];
-            } elseif ($listener instanceof \Closure) {
-                $results[] = '{closure}()';
             } else {
                 $results[] = 'Unknown type!';
             }


### PR DESCRIPTION
I am targeting this branch, because i was getting an error from [SontataTranslationBundle](https://github.com/sonata-project/SonataTranslationBundle). This bundle fires an ```sonata.block.event.sonata.admin.list.table.top``` event, which is a ```\Closure``` in the end.

## Changelog
```
Changed order of statements in the getEventListeners() method. 

### Fixed

- Issues where you pass in a \Closure class
```

## Subject

Bugfix: Fixed bug where the \Closure statement if never reached because it's already in the is_object() clause. The ```Closure``` class is an object, so therefore the third elseif statement is never reached.
