### PR TITLE
Fix Cannot use object of type Closure as array

### DIFF
--- a/Templating/Helper/BlockHelper.php
+++ b/Templating/Helper/BlockHelper.php
@@ -431,12 +431,12 @@ class BlockHelper extends Helper
         $results = array();
 
         foreach ($this->eventDispatcher->getListeners($eventName) as $listener) {
-            if (is_object($listener[0])) {
+            if ($listener instanceof \Closure) {
+                $results[] = '{closure}()';
+            } elseif (is_object($listener[0])) {
                 $results[] = get_class($listener[0]);
             } elseif (is_string($listener[0])) {
                 $results[] = $listener[0];
-            } elseif ($listener instanceof \Closure) {
-                $results[] = '{closure}()';
             } else {
                 $results[] = 'Unknown type!';
             }


### PR DESCRIPTION
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, but it should be done on master too.

Closes #{384}

## Changelog
```markdown

### Fixed
- BlockHelper : Cannot use object of type Closure as array

```

## Subject

After upgrading to Symfony 3.3, I got this error: 
"Cannot use object of type Closure as array"

I think, we should test that $listener is a closure before testing that the type of the first key of a variable that is maybe not an array.
