### PR TITLE
Only add classes to compile on PHP < 7.0

### DIFF
--- a/DependencyInjection/SonataBlockExtension.php
+++ b/DependencyInjection/SonataBlockExtension.php
@@ -72,7 +72,9 @@ class SonataBlockExtension extends Extension
         $this->configureProfiler($container, $config);
         $this->configureException($container, $config);
         $this->configureMenus($container, $config);
-        $this->configureClassesToCompile();
+        if (\PHP_VERSION_ID < 70000) {
+            $this->configureClassesToCompile();
+        }
 
         if ($config['templates']['block_base'] === null) {
             if (isset($bundles['SonataPageBundle'])) {


### PR DESCRIPTION
I am targeting this branch, because this fix a deprecation warning and is BC.

## Changelog

```markdown
### Fixed
- deprecation notices related to `addClassesToCompile`
```

## Subject

Only call addClassesToCompile on PHP < 7.0 since it is deprecated and doesn't improve performances with PHP >= 7.0