### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,19 +17,19 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.1",
         "doctrine/common": "^2.3",
         "sonata-project/cache": "^1.0",
         "sonata-project/core-bundle": "^3.4",
-        "symfony/form": "^2.3 || ^3.0",
-        "symfony/http-kernel": "^2.3 || ^3.0"
+        "symfony/form": "^2.8 || ^3.2",
+        "symfony/http-kernel": "^2.8 || ^3.2"
     },
     "require-dev": {
         "jms/di-extra-bundle": "^1.7",
         "knplabs/knp-menu-bundle": "^2.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/admin-bundle": "^3.22",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "conflict": {
         "jms/di-extra-bundle": "<1.7.0"


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of PHP and Symfony.
```
