### PR TITLE
Fix argument replacement of a non-existent one

### DIFF
--- a/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -39,7 +39,7 @@ class TweakCompilerPass implements CompilerPassInterface
 
             // Replace empty block id with service id
             if (empty($arguments) || strlen($arguments[0]) == 0) {
-                $definition->replaceArgument(0, $id);
+                $definition->setArgument(0, $id);
             } elseif ($id != $arguments[0] && 0 !== strpos(
                 $container->getParameterBag()->resolveValue($definition->getClass()),
                 'Sonata\\BlockBundle\\Block\\Service\\'


### PR DESCRIPTION
I am targeting this branch, because it's a bugfix.

## Changelog

```markdown
### Fixed
- OutOfBoundsException while replacing block service default name argument
```

## Subject

#374 was not enough. If the service arguments list is empty, we can't call `replaceArgument`.

The `setArgument` method works for the both cases because it set the argument like a :pig:  without checking anything.

This is buggy since https://github.com/symfony/symfony/commit/428814b25ddd7b0bfbf56d0f4cc3879c3e9bc793 and also affect service autowiring like this:

```
services:
    _defaults:
        autowire: true
        autoconfigure: true
        public: false

    _instanceof:
        Sonata\BlockBundle\Block\Service\BlockServiceInterface:
            tags: [ sonata.block ]
```