### PR TITLE
Deprecate options resolver trick

### DIFF
--- a/Resources/stubs/symfony2.php
+++ b/Resources/stubs/symfony2.php
@@ -12,6 +12,9 @@
 namespace Symfony\Component\OptionsResolver;
 
 if (!interface_exists('Symfony\Component\OptionsResolver\OptionsResolverInterface')) {
+    /**
+     * @deprecated since 3.x, to be removed in 4.0. Use \Symfony\Component\OptionsResolver\OptionsResolver instead.
+     */
     interface OptionsResolverInterface
     {
     }

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,12 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated options resolver BC tricks.
+
+Since we require at least Symfony 2.8, this BC trick is not needed anymore.
+
+The concerned class and interface should be internal, but as they was not marked like this, we will deprecate them.
+
 UPGRADE FROM 3.2 to 3.3
 =======================
 

--- a/Util/OptionsResolver.php
+++ b/Util/OptionsResolver.php
@@ -13,6 +13,9 @@ namespace Sonata\BlockBundle\Util;
 
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
+/**
+ * @deprecated since version 3.x, to be removed in 4.0. Use \Symfony\Component\OptionsResolver\OptionsResolver instead.
+ */
 class OptionsResolver extends \Symfony\Component\OptionsResolver\OptionsResolver implements OptionsResolverInterface
 {
 }


### PR DESCRIPTION
I am targeting this branch, because it's a deprecation.

## Changelog

```markdown
### Deprecated
- Option resolver BC trick.
```

## Subject

It is not needed anymore.