### PR TITLE
Implement reset method in BlockDataCollector

### DIFF
--- a/Profiler/DataCollector/BlockDataCollector.php
+++ b/Profiler/DataCollector/BlockDataCollector.php
@@ -177,4 +177,15 @@ class BlockDataCollector implements DataCollectorInterface, \Serializable
     {
         return 'block';
     }
+
+    /**
+     * Resets this data collector to its initial state.
+     */
+    public function reset()
+    {
+        $this->blocks = [];
+        $this->containers = [];
+        $this->realBlocks = [];
+        $this->events = [];
+    }
 }

--- a/Tests/Profiler/DataCollector/BlockDataCollectorTest.php
+++ b/Tests/Profiler/DataCollector/BlockDataCollectorTest.php
@@ -45,7 +45,7 @@ class BlockDataCollectorTest extends TestCase
             '1' => '2',
             '3' => '4',
         ];
-        $this->assertEquals($expectedEvents, $blockDataCollector->getEvents());
+        $this->assertSame($expectedEvents, $blockDataCollector->getEvents());
 
         $expectedBlocks = [
             '_events' => [
@@ -59,26 +59,26 @@ class BlockDataCollectorTest extends TestCase
                 'type' => 'another_type',
             ],
         ];
-        $this->assertEquals($expectedBlocks, $blockDataCollector->getBlocks());
+        $this->assertSame($expectedBlocks, $blockDataCollector->getBlocks());
 
         $expectedContainers = [
             'test1' => [
                 'type' => 'container',
             ]
         ];
-        $this->assertEquals($expectedContainers, $blockDataCollector->getContainers());
+        $this->assertSame($expectedContainers, $blockDataCollector->getContainers());
 
         $expectedRealBlocks = [
             'test2' => [
                 'type' => 'another_type',
             ]
         ];
-        $this->assertEquals($expectedRealBlocks, $blockDataCollector->getRealBlocks());
+        $this->assertSame($expectedRealBlocks, $blockDataCollector->getRealBlocks());
 
         $blockDataCollector->reset();
-        $this->assertEquals([], $blockDataCollector->getEvents());
-        $this->assertEquals([], $blockDataCollector->getBlocks());
-        $this->assertEquals([], $blockDataCollector->getContainers());
-        $this->assertEquals([], $blockDataCollector->getRealBlocks());
+        $this->assertSame([], $blockDataCollector->getEvents());
+        $this->assertSame([], $blockDataCollector->getBlocks());
+        $this->assertSame([], $blockDataCollector->getContainers());
+        $this->assertSame([], $blockDataCollector->getRealBlocks());
     }
 }

--- a/Tests/Profiler/DataCollector/BlockDataCollectorTest.php
+++ b/Tests/Profiler/DataCollector/BlockDataCollectorTest.php
@@ -14,7 +14,7 @@ namespace Sonata\BlockBundle\Tests\Profiler\DataCollector;
 use PHPUnit\Framework\TestCase;
 use Sonata\BlockBundle\Profiler\DataCollector\BlockDataCollector;
 
-class BlockDataCollectorTest extends TestCase
+final class BlockDataCollectorTest extends TestCase
 {
     public function testBlockDataCollector()
     {

--- a/Tests/Profiler/DataCollector/BlockDataCollectorTest.php
+++ b/Tests/Profiler/DataCollector/BlockDataCollectorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Profiler\DataCollector;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Profiler\DataCollector\BlockDataCollector;
+
+class BlockDataCollectorTest extends TestCase
+{
+    public function testBlockDataCollector()
+    {
+        $blockHelper = $this->createMock('Sonata\BlockBundle\Templating\Helper\BlockHelper');
+        $blockHelper->expects($this->once())->method('getTraces')->will($this->returnValue([
+            '_events' => [
+                '1' => '2',
+                '3' => '4',
+            ],
+            'test1' => [
+                'type' => 'container',
+            ],
+            'test2' => [
+                'type' => 'another_type',
+            ],
+        ]));
+
+        $containerTypes = ["container"];
+
+        $blockDataCollector = new BlockDataCollector($blockHelper, $containerTypes);
+
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $response = $this->createMock('Symfony\Component\HttpFoundation\Response');
+
+        $blockDataCollector->collect($request, $response);
+
+        $expectedEvents = [
+            '1' => '2',
+            '3' => '4',
+        ];
+        $this->assertEquals($expectedEvents, $blockDataCollector->getEvents());
+
+        $expectedBlocks = [
+            '_events' => [
+                '1' => '2',
+                '3' => '4',
+            ],
+            'test1' => [
+                'type' => 'container',
+            ],
+            'test2' => [
+                'type' => 'another_type',
+            ],
+        ];
+        $this->assertEquals($expectedBlocks, $blockDataCollector->getBlocks());
+
+        $expectedContainers = [
+            'test1' => [
+                'type' => 'container',
+            ]
+        ];
+        $this->assertEquals($expectedContainers, $blockDataCollector->getContainers());
+
+        $expectedRealBlocks = [
+            'test2' => [
+                'type' => 'another_type',
+            ]
+        ];
+        $this->assertEquals($expectedRealBlocks, $blockDataCollector->getRealBlocks());
+
+        $blockDataCollector->reset();
+        $this->assertEquals([], $blockDataCollector->getEvents());
+        $this->assertEquals([], $blockDataCollector->getBlocks());
+        $this->assertEquals([], $blockDataCollector->getContainers());
+        $this->assertEquals([], $blockDataCollector->getRealBlocks());
+    }
+}


### PR DESCRIPTION
Since Symfony 3.4 classes implementing DataCollectorInterface should implement reset() method.

I am targeting 3.x branch, because I'm only adding new method. No BC changes. There's no reason for waiting for new major release.

Closes https://github.com/sonata-project/SonataAdminBundle/issues/4699
Didn't know how else should I refer to issue in another bundle...

## Changelog

```markdown
### Added
- Implement reset method in `BlockDataCollector` to be compatible with Symfony 3.4
```
## Subject
Added one method to BlockDataCollector to implement new version of DataCollectorInterface correctly.
