### PR TITLE
Register commands as services

### DIFF
--- a/Resources/config/commands.xml
+++ b/Resources/config/commands.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Sonata\BlockBundle\Command\DebugBlocksCommand" class="Sonata\BlockBundle\Command\DebugBlocksCommand">
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>

--- a/src/DependencyInjection/SonataBlockExtension.php
+++ b/src/DependencyInjection/SonataBlockExtension.php
@@ -61,6 +61,7 @@ class SonataBlockExtension extends Extension
         $loader->load('form.xml');
         $loader->load('core.xml');
         $loader->load('exception.xml');
+        $loader->load('commands.xml');
 
         $this->fixConfigurationDeprecation($config);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because deprecation notices are thrown after update to Symfony 3.4.
Closes https://github.com/sonata-project/SonataAdminBundle/issues/4703
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Register commands as services to prevent deprecation notices on Symfony 3.4
```


<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->


## Subject
After updating Symfony version to 3.4 the following deprecation notices are thrown:
> Auto-registration of the command "Sonata\BlockBundle\Command\DebugBlocksCommand" is deprecated since Symfony 3.4 and won't be supported in 4.0. Use PSR-4 based service discovery instead.
