### PR TITLE
Removed pre sf2.8 bc code

### DIFF
--- a/Block/BlockContextManager.php
+++ b/Block/BlockContextManager.php
@@ -187,24 +187,13 @@ class BlockContextManager implements BlockContextManagerInterface
             'ttl' => (int) $block->getTtl(),
         ]);
 
-        // TODO: Remove it when bumping requirements to SF 2.6+
-        if (method_exists($optionsResolver, 'setDefined')) {
-            $optionsResolver
-                ->addAllowedTypes('use_cache', 'bool')
-                ->addAllowedTypes('extra_cache_keys', 'array')
-                ->addAllowedTypes('attr', 'array')
-                ->addAllowedTypes('ttl', 'int')
-                ->addAllowedTypes('template', ['string', 'bool'])
-            ;
-        } else {
-            $optionsResolver->addAllowedTypes([
-                'use_cache' => ['bool'],
-                'extra_cache_keys' => ['array'],
-                'attr' => ['array'],
-                'ttl' => ['int'],
-                'template' => ['string', 'bool'],
-            ]);
-        }
+        $optionsResolver
+            ->addAllowedTypes('use_cache', 'bool')
+            ->addAllowedTypes('extra_cache_keys', 'array')
+            ->addAllowedTypes('attr', 'array')
+            ->addAllowedTypes('ttl', 'int')
+            ->addAllowedTypes('template', ['string', 'bool'])
+        ;
 
         // add type and class settings for block
         $class = ClassUtils::getClass($block);

--- a/Resources/views/Profiler/block.html.twig
+++ b/Resources/views/Profiler/block.html.twig
@@ -1,24 +1,13 @@
 {% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
 
 {% block toolbar %}
-    {% set profiler_markup_version = profiler_markup_version|default(1) %}
-
     <div class="sf-toolbar-block">
-        {% if profiler_markup_version == 1 %}
+        <a href="{{ path('_profiler', { 'token': token, 'panel': name }) }}">
             <div class="sf-toolbar-icon">
-                <a href="{{ path('_profiler', { 'token': token, 'panel': name }) }}">
-                    {# fake image span #}<span style="width:0px; height: 28px; vertical-align: middle;"></span>
-                    <span class="sf-toolbar-status">{{ collector.getTotalBlock() }}</span> blocks
-                </a>
+                {{ include('@SonataBlock/Profiler/icon.svg') }}
+                <span class="sf-toolbar-value">{{ collector.getTotalBlock() }}</span>
             </div>
-        {% else %}
-            <a href="{{ path('_profiler', { 'token': token, 'panel': name }) }}">
-                <div class="sf-toolbar-icon">
-                    {{ include('@SonataBlock/Profiler/icon.svg') }}
-                    <span class="sf-toolbar-value">{{ collector.getTotalBlock() }}</span>
-                </div>
-            </a>
-        {% endif %}
+        </a>
 
         <div class="sf-toolbar-info">
             <div class="sf-toolbar-info-piece">
@@ -29,16 +18,7 @@
                 <b>Containers</b>
                 <span>{{ collector.containers|length }}</span>
             </div>
-            {% if profiler_markup_version == 1 %}
-                {# don't show the total number of blocks in the info in the new design,
-                it's already shown in the toolbar #}
-                <div class="sf-toolbar-info-piece">
-                    <b>Total Blocks</b>
-                    <span>{{ collector.getTotalBlock() }}</span>
-                </div>
-            {% endif %}
             <div class="sf-toolbar-info-piece">
-                {% if profiler_markup_version == 1 %}<hr />{% endif %}
                 <b>Events</b>
                 <span>{{ collector.events|length }}</span>
             </div>
@@ -59,9 +39,6 @@
 {% endblock %}
 
 {% block panel %}
-    {# NEXT_MAJOR : remove this when Symfony Requirement will be bumped to 2.8+ #}
-    {% set profiler_markup_version = profiler_markup_version|default(1) %}
-
     <h2>Events Blocks</h2>
     <table>
         <tr>
@@ -95,24 +72,15 @@
 
     <h2>Real Blocks</h2>
     {% set blocks = collector.realBlocks %}
-    {% if profiler_markup_version == 1 %}
-        {{ block('table') }}
-    {% else %}
-        <div class="tab-content">
-            {{ block('table_v2') }}
-        </div>
-    {% endif %}
+    <div class="tab-content">
+        {{ block('table_v2') }}
+    </div>
 
     <h2>Containers Blocks</h2>
     {% set blocks = collector.containers %}
-    {% if profiler_markup_version == 1 %}
-        {{ block('table') }}
-    {% else %}
-        <div class="tab-content">
-            {{ block('table_v2') }}
-        </div>
-    {% endif %}
-
+    <div class="tab-content">
+        {{ block('table_v2') }}
+    </div>
 {% endblock %}
 
 {% block table %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a code cleanup for the 3.x branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove pre sf2.8 bc code
```

## Subject

Some code cleanup after the <sf2.8 dependency change.
