### PR TITLE
Remove trigger_error for deprecation

### DIFF
--- a/Tests/Block/AbstractBlockServiceTest.php
+++ b/Tests/Block/AbstractBlockServiceTest.php
@@ -13,12 +13,6 @@ namespace Sonata\BlockBundle\Tests\Block;
 
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\AbstractBlockServiceTest class is deprecated since version 3.1 and will be removed in 4.0.'
-    .' Use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase instead.',
-    E_USER_DEPRECATED
-);
-
 /**
  * NEXT_MAJOR: remove this class.
  *


### PR DESCRIPTION
It does not work properly with the weak_vendors option and is not
mandatory.

I am targeting this branch, because it's a Travis fix.
