### PR TITLE
Implement reset method in BlockDataCollector

### DIFF
--- a/src/Profiler/DataCollector/BlockDataCollector.php
+++ b/src/Profiler/DataCollector/BlockDataCollector.php
@@ -177,4 +177,15 @@ class BlockDataCollector implements DataCollectorInterface, \Serializable
     {
         return 'block';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->blocks = [];
+        $this->containers = [];
+        $this->realBlocks = [];
+        $this->events = [];
+    }
 }

--- a/tests/Profiler/DataCollector/BlockDataCollectorTest.php
+++ b/tests/Profiler/DataCollector/BlockDataCollectorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Profiler\DataCollector;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Profiler\DataCollector\BlockDataCollector;
+use Sonata\BlockBundle\Templating\Helper\BlockHelper;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author Olivier Paradis <paradis.olivier@gmail.com>
+ */
+final class BlockDataCollectorTest extends TestCase
+{
+    public function testBlockDataCollector()
+    {
+        $blockHelper = $this->prophesize(BlockHelper::class);
+        $request = $this->prophesize(Request::class);
+        $response = $this->prophesize(Response::class);
+
+        $blockDataCollector = new BlockDataCollector($blockHelper->reveal(), ['container']);
+
+        $expectedEvents = ['1' => '2', '3' => '4'];
+        $expectedBlocks = [
+            '_events' => ['1' => '2', '3' => '4'],
+            'test1' => ['type' => 'container'],
+            'test2' => ['type' => 'another_type'],
+        ];
+        $expectedContainers = ['test1' => ['type' => 'container']];
+        $expectedRealBlocks = ['test2' => ['type' => 'another_type']];
+
+        $blockHelper->getTraces()->willReturn([
+            '_events' => ['1' => '2', '3' => '4'],
+            'test1' => ['type' => 'container'],
+            'test2' => ['type' => 'another_type'],
+        ]);
+
+        $blockDataCollector->collect($request->reveal(), $response->reveal());
+
+        $this->assertSame($expectedEvents, $blockDataCollector->getEvents());
+        $this->assertSame($expectedBlocks, $blockDataCollector->getBlocks());
+        $this->assertSame($expectedContainers, $blockDataCollector->getContainers());
+        $this->assertSame($expectedRealBlocks, $blockDataCollector->getRealBlocks());
+
+        $blockDataCollector->reset();
+
+        $this->assertSame([], $blockDataCollector->getEvents());
+        $this->assertSame([], $blockDataCollector->getBlocks());
+        $this->assertSame([], $blockDataCollector->getContainers());
+        $this->assertSame([], $blockDataCollector->getRealBlocks());
+    }
+}


### PR DESCRIPTION
Redo of: https://github.com/sonata-project/SonataBlockBundle/pull/414
Allows: https://github.com/sonata-project/SonataBlockBundle/pull/438

Since Symfony 3.4 classes implementing DataCollectorInterface should implement reset() method.

I am targeting 3.x branch, because I'm only adding new method. No BC changes. There's no reason for waiting for new major release.

Closes https://github.com/sonata-project/SonataAdminBundle/issues/4699

## Changelog

```markdown
### Added
- Implement reset method in `BlockDataCollector` to be compatible with Symfony 3.4
```
## Subject
Added one method to BlockDataCollector to implement new version of DataCollectorInterface correctly.
