### PR TITLE
added class alias for phpunit testcase class

### DIFF
--- a/src/Test/AbstractBlockServiceTestCase.php
+++ b/src/Test/AbstractBlockServiceTestCase.php
@@ -18,6 +18,13 @@ use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/*
+ * NEXT_MAJOR: remove check and extend PHPUnit\Framework\TestCase when dropping support for PHPUnit 4
+ */
+if (!class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
+}
+
 /**
  * Abstract test class for block service tests.
  *


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `AbstractBlockServiceTestCase` now works with PHPUnit >= 6.0
```


## Subject

I got an error when using phpunit 6.0 and extending the `AbstractBlockServiceTestCase`.

```
Fatal error: Class 'PHPUnit_Framework_TestCase' not found in /var/www/vendor/sonata-project/block-bundle/src/Test/AbstractBlockServiceTestCase.php on line 26
```

I tried to fix it by a class alias.