### PR TITLE
Rewrote defining menu blocks

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,12 @@
 UPGRADE 3.x
 ===========
 
+## Rewrote menu blocks
+
+Defining menu blocks by using a `<tag name="sonata.block.menu"/>` tag was removed, because it never worked properly.
+
+Use the existing `<tag name="knp_menu.menu" alias="app.main"/>` tag to define a menu block instead.
+
 UPGRADE FROM 3.4 to 3.5
 =======================
 

--- a/docs/reference/provided_blocks.rst
+++ b/docs/reference/provided_blocks.rst
@@ -33,14 +33,14 @@ MenuBlockService
 
 This block service displays a KNP Menu.
 
-Defining a menu could be done by inserting the ``sonata.block.menu`` tag.
+Defining a menu could be done by inserting the ``knp_menu.menu`` tag.
 
 .. configuration-block::
 
     .. code-block:: xml
 
         <service id="sonata.block.menu.main" class="Sonata\BlockBundle\Menu\MainMenu">
-            <tag name="sonata.block.menu" />
+            <tag name="knp_menu.menu" alias="sonata.main" />
         </service>
 
 Upon configuration, you may set some rendering options (see KNP Doc for those).

--- a/src/Block/Service/MenuBlockService.php
+++ b/src/Block/Service/MenuBlockService.php
@@ -161,6 +161,7 @@ class MenuBlockService extends AbstractAdminBlockService
     {
         $choiceOptions = [
             'required' => false,
+            'choice_translation_domain' => 'SonataBlockBundle',
         ];
 
         $choices = $this->menuRegistry->getAliasNames();

--- a/src/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -54,8 +54,13 @@ class TweakCompilerPass implements CompilerPassInterface
             $manager->addMethodCall('add', [$id, $id, isset($parameters[$id]) ? $parameters[$id]['contexts'] : []]);
         }
 
-        foreach ($container->findTaggedServiceIds('sonata.block.menu') as $id => $attributes) {
-            $registry->addMethodCall('add', [new Reference($id)]);
+        foreach ($container->findTaggedServiceIds('knp_menu.menu') as $id => $tags) {
+            foreach ($tags as $attributes) {
+                if (empty($attributes['alias'])) {
+                    throw new \InvalidArgumentException(sprintf('The alias is not defined in the "knp_menu.menu" tag for the service "%s"', $id));
+                }
+                $registry->addMethodCall('add', [$attributes['alias']]);
+            }
         }
 
         $services = [];

--- a/src/Menu/MenuBuilderInterface.php
+++ b/src/Menu/MenuBuilderInterface.php
@@ -16,6 +16,8 @@ use Knp\Menu\ItemInterface;
 
 /**
  * @author Christian Gripp <mail@core23.de>
+ *
+ * @deprecated since 3.x, to be removed with 4.0.
  */
 interface MenuBuilderInterface
 {

--- a/src/Menu/MenuRegistry.php
+++ b/src/Menu/MenuRegistry.php
@@ -17,11 +17,6 @@ namespace Sonata\BlockBundle\Menu;
 final class MenuRegistry implements MenuRegistryInterface
 {
     /**
-     * @var MenuBuilderInterface[]
-     */
-    private $menus = [];
-
-    /**
      * @var string[]
      */
     private $names = [];
@@ -48,12 +43,18 @@ final class MenuRegistry implements MenuRegistryInterface
     /**
      * {@inheritdoc}
      */
-    public function add(MenuBuilderInterface $menu)
+    public function add($menu)
     {
-        $alias = $this->buildMenuAlias($menu);
+        if ($menu instanceof MenuBuilderInterface) {
+            @trigger_error(
+                'Adding a '.MenuBuilderInterface::class.' is deprecated since 3.x and will be removed in 4.0.',
+                E_USER_DEPRECATED
+            );
 
-        $this->menus[$alias] = $menu;
-        $this->names[$alias] = $menu->getName();
+            return;
+        }
+
+        $this->names[$menu] = $menu;
     }
 
     /**
@@ -62,23 +63,5 @@ final class MenuRegistry implements MenuRegistryInterface
     public function getAliasNames()
     {
         return $this->names;
-    }
-
-    /**
-     * Returns the menu method name.
-     *
-     * @param MenuBuilderInterface $menu
-     *
-     * @return string
-     */
-    private function buildMenuAlias(MenuBuilderInterface $menu)
-    {
-        $reflector = new \ReflectionClass($menu);
-        $namespace = $reflector->getNamespaceName();
-        $class = $reflector->getName();
-
-        $bundle = str_replace('\\', '', preg_replace('/(.*Bundle)\\\\.*/i', '$1', $namespace));
-
-        return $bundle.':'.$class.':buildMenu';
     }
 }

--- a/src/Menu/MenuRegistryInterface.php
+++ b/src/Menu/MenuRegistryInterface.php
@@ -19,9 +19,9 @@ interface MenuRegistryInterface
     /**
      * Adds a new menu.
      *
-     * @param MenuBuilderInterface $name
+     * @param string $name
      */
-    public function add(MenuBuilderInterface $name);
+    public function add($name);
 
     /**
      * Returns all alias names.

--- a/tests/Block/Service/MenuBlockServiceTest.php
+++ b/tests/Block/Service/MenuBlockServiceTest.php
@@ -48,6 +48,7 @@ class MenuBlockServiceTest extends AbstractBlockServiceTestCase
 
         $choiceOptions = [
             'required' => false,
+            'choice_translation_domain' => 'SonataBlockBundle',
         ];
 
         $choices = [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataBlockBundle/issues/389

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - Changed `MenuRegistry::add` method signature to allow string values instead of `MenuBuilderInterface`

### Deprecated
 - deprecated `sonata.block.menu` tag in favor of the existing `knp_menu.menu` tag
 - deprecated `MenuBuilderInterface` class
```

## Subject

The PR https://github.com/sonata-project/SonataBlockBundle/pull/341 introduced a menu registry which never worked properly. This PR is a bugfix, so all defined `knp_menu.menu` menus will be added to the registry and can be selected in the `MenuBlockService`.

This PR is technically a BC break, but no one could ever haved used the menu registry.