### PR TITLE
Removed form type aliases

### DIFF
--- a/src/Block/Service/ContainerBlockService.php
+++ b/src/Block/Service/ContainerBlockService.php
@@ -13,8 +13,12 @@ namespace Sonata\BlockBundle\Block\Service;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Form\Type\ContainerTemplateType;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -32,20 +36,20 @@ class ContainerBlockService extends AbstractAdminBlockService
     {
         $formMapper->add('enabled');
 
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['code', 'text', [
+                ['code', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_code',
                 ]],
-                ['layout', 'textarea', [
+                ['layout', TextareaType::class, [
                     'label' => 'form.label_layout',
                 ]],
-                ['class', 'text', [
+                ['class', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_class',
                 ]],
-                ['template', 'sonata_type_container_template_choice', [
+                ['template', ContainerTemplateType::class, [
                     'label' => 'form.label_template',
                 ]],
             ],

--- a/src/Block/Service/MenuBlockService.php
+++ b/src/Block/Service/MenuBlockService.php
@@ -18,9 +18,13 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Menu\MenuRegistry;
 use Sonata\BlockBundle\Menu\MenuRegistryInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -106,7 +110,7 @@ class MenuBlockService extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $form, BlockInterface $block)
     {
-        $form->add('settings', 'sonata_type_immutable_array', [
+        $form->add('settings', ImmutableArrayType::class, [
             'keys' => $this->getFormSettingsKeys(),
             'translation_domain' => 'SonataBlockBundle',
         ]);
@@ -175,40 +179,40 @@ class MenuBlockService extends AbstractAdminBlockService
         $choiceOptions['choices'] = array_flip($this->menuRegistry->getAliasNames());
 
         return [
-            ['title', 'text', [
+            ['title', TextType::class, [
                 'required' => false,
                 'label' => 'form.label_title',
             ]],
-            ['cache_policy', 'choice', [
+            ['cache_policy', ChoiceType::class, [
                 'label' => 'form.label_cache_policy',
                 'choices' => ['public', 'private'],
             ]],
-            ['menu_name', 'choice', $choiceOptions],
-            ['safe_labels', 'checkbox', [
+            ['menu_name', ChoiceType::class, $choiceOptions],
+            ['safe_labels', CheckboxType::class, [
                 'required' => false,
                 'label' => 'form.label_safe_labels',
             ]],
-            ['current_class', 'text', [
+            ['current_class', TextType::class, [
                 'required' => false,
                 'label' => 'form.label_current_class',
             ]],
-            ['first_class', 'text', [
+            ['first_class', TextType::class, [
                 'required' => false,
                 'label' => 'form.label_first_class',
             ]],
-            ['last_class', 'text', [
+            ['last_class', TextType::class, [
                 'required' => false,
                 'label' => 'form.label_last_class',
             ]],
-            ['menu_class', 'text', [
+            ['menu_class', TextType::class, [
                 'required' => false,
                 'label' => 'form.label_menu_class',
             ]],
-            ['children_class', 'text', [
+            ['children_class', TextType::class, [
                 'required' => false,
                 'label' => 'form.label_children_class',
             ]],
-            ['menu_template', 'text', [
+            ['menu_template', TextType::class, [
                 'required' => false,
                 'label' => 'form.label_menu_template',
             ]],

--- a/src/Block/Service/RssBlockService.php
+++ b/src/Block/Service/RssBlockService.php
@@ -14,8 +14,11 @@ namespace Sonata\BlockBundle\Block\Service;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\CoreBundle\Validator\ErrorElement;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -41,13 +44,13 @@ class RssBlockService extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['url', 'url', [
+                ['url', UrlType::class, [
                     'required' => false,
                     'label' => 'form.label_url',
                 ]],
-                ['title', 'text', [
+                ['title', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_title',
                 ]],

--- a/src/Block/Service/TemplateBlockService.php
+++ b/src/Block/Service/TemplateBlockService.php
@@ -14,6 +14,7 @@ namespace Sonata\BlockBundle\Block\Service;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -39,7 +40,7 @@ class TemplateBlockService extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['template', null, [
                     'label' => 'form.label_template',

--- a/src/Block/Service/TextBlockService.php
+++ b/src/Block/Service/TextBlockService.php
@@ -14,7 +14,9 @@ namespace Sonata\BlockBundle\Block\Service;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -39,9 +41,9 @@ class TextBlockService extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['content', 'textarea', [
+                ['content', TextareaType::class, [
                     'label' => 'form.label_content',
                 ]],
             ],

--- a/src/Form/Type/ContainerTemplateType.php
+++ b/src/Form/Type/ContainerTemplateType.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\BlockBundle\Form\Type;
 
+use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -54,7 +55,7 @@ class ContainerTemplateType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return ChoiceType::class;
     }
 
     /**

--- a/src/Form/Type/ServiceListType.php
+++ b/src/Form/Type/ServiceListType.php
@@ -13,6 +13,7 @@ namespace Sonata\BlockBundle\Form\Type;
 
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -50,7 +51,7 @@ class ServiceListType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
+        return ChoiceType::class;
     }
 
     /**

--- a/tests/Block/Service/MenuBlockServiceTest.php
+++ b/tests/Block/Service/MenuBlockServiceTest.php
@@ -15,6 +15,10 @@ use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\Service\MenuBlockService;
 use Sonata\BlockBundle\Menu\MenuRegistryInterface;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormTypeInterface;
 
 class MenuBlockServiceTest extends AbstractBlockServiceTestCase
@@ -63,42 +67,42 @@ class MenuBlockServiceTest extends AbstractBlockServiceTestCase
         ];
 
         $formMapper->expects($this->once())->method('add')
-            ->with('settings', 'sonata_type_immutable_array', [
+            ->with('settings', ImmutableArrayType::class, [
                 'keys' => [
-                    ['title', 'text', [
+                    ['title', TextType::class, [
                         'required' => false,
                         'label' => 'form.label_title',
                     ]],
-                    ['cache_policy', 'choice', [
+                    ['cache_policy', ChoiceType::class, [
                         'label' => 'form.label_cache_policy',
                         'choices' => ['public', 'private'],
                     ]],
-                    ['menu_name', 'choice', $choiceOptions],
-                    ['safe_labels', 'checkbox', [
+                    ['menu_name', ChoiceType::class, $choiceOptions],
+                    ['safe_labels', CheckboxType::class, [
                         'required' => false,
                         'label' => 'form.label_safe_labels',
                     ]],
-                    ['current_class', 'text', [
+                    ['current_class', TextType::class, [
                         'required' => false,
                         'label' => 'form.label_current_class',
                     ]],
-                    ['first_class', 'text', [
+                    ['first_class', TextType::class, [
                         'required' => false,
                         'label' => 'form.label_first_class',
                     ]],
-                    ['last_class', 'text', [
+                    ['last_class', TextType::class, [
                         'required' => false,
                         'label' => 'form.label_last_class',
                     ]],
-                    ['menu_class', 'text', [
+                    ['menu_class', TextType::class, [
                         'required' => false,
                         'label' => 'form.label_menu_class',
                     ]],
-                    ['children_class', 'text', [
+                    ['children_class', TextType::class, [
                         'required' => false,
                         'label' => 'form.label_children_class',
                     ]],
-                    ['menu_template', 'text', [
+                    ['menu_template', TextType::class, [
                         'required' => false,
                         'label' => 'form.label_menu_template',
                     ]],

--- a/tests/Form/Type/ServiceListTypeTest.php
+++ b/tests/Form/Type/ServiceListTypeTest.php
@@ -13,6 +13,7 @@ namespace Sonata\BlockBundle\Tests\Form\Type;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\BlockBundle\Form\Type\ServiceListType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ServiceListTypeTest extends TestCase
@@ -24,7 +25,7 @@ class ServiceListTypeTest extends TestCase
         $type = new ServiceListType($blockServiceManager);
 
         $this->assertEquals('sonata_block_service_choice', $type->getName());
-        $this->assertEquals('choice', $type->getParent());
+        $this->assertEquals(ChoiceType::class, $type->getParent());
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Changed
- Removed usage of old form type aliases
```
