### PR TITLE
Make services public

### DIFF
--- a/src/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -34,6 +34,7 @@ class TweakCompilerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('sonata.block') as $id => $tags) {
             $definition = $container->getDefinition($id);
+            $definition->setPublic(true);
 
             $arguments = $definition->getArguments();
 

--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -6,16 +6,16 @@
             <argument>%kernel.debug%</argument>
             <argument type="service" id="logger" on-invalid="ignore"/>
         </service>
-        <service id="sonata.block.menu.registry" class="Sonata\BlockBundle\Menu\MenuRegistry">
+        <service id="sonata.block.menu.registry" class="Sonata\BlockBundle\Menu\MenuRegistry" public="true">
             <argument/>
         </service>
-        <service id="sonata.block.context_manager.default" class="Sonata\BlockBundle\Block\BlockContextManager">
+        <service id="sonata.block.context_manager.default" class="Sonata\BlockBundle\Block\BlockContextManager" public="true">
             <argument type="service" id="sonata.block.loader.chain"/>
             <argument type="service" id="sonata.block.manager"/>
             <argument>%sonata_block.cache_blocks%</argument>
             <argument type="service" id="logger" on-invalid="ignore"/>
         </service>
-        <service id="sonata.block.renderer.default" class="Sonata\BlockBundle\Block\BlockRenderer">
+        <service id="sonata.block.renderer.default" class="Sonata\BlockBundle\Block\BlockRenderer" public="true">
             <argument type="service" id="sonata.block.manager"/>
             <argument type="service" id="sonata.block.exception.strategy.manager"/>
             <argument type="service" id="logger" on-invalid="ignore"/>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
 - make services explicit public
 - Autoregister blocks as public services 
```

## Subject

This patch is needed for sf 4.