### PR TITLE
Use Templating Component without "templating" service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,10 @@
         "doctrine/common": "^2.3",
         "sonata-project/cache": "^1.0 || ^2.0",
         "sonata-project/core-bundle": "^3.4",
+        "symfony/asset": "^2.8 || ^3.2 || ^4.0",
         "symfony/form": "^2.8 || ^3.2 || ^4.0",
         "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
+        "symfony/templating": "^2.8 || ^3.2 || ^4.0",
         "symfony/twig-bundle": "^2.8 || ^3.2 || ^4.0",
         "twig/twig": "^1.34 || ^2.0"
     },

--- a/docs/cookbook/rapid_prototyping.rst
+++ b/docs/cookbook/rapid_prototyping.rst
@@ -17,7 +17,7 @@ The TemplateController_ is a native Symfony controller that can be used to rende
         path: /privacy
         defaults:
             _controller: FrameworkBundle:Template:template
-            template:    'AcmeBundle:Static:privacy.html.twig'
+            template:    '@Acme/Static/privacy.html.twig'
 
 The Template Block Service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -33,7 +33,7 @@ The usage is very simple:
 .. code-block:: jinja
 
     {{ sonata_block_render({ 'type': 'sonata.block.service.template' }, {
-        'template': 'SonataDemoBundle:Block:myblock.html'
+        'template': '@SonataDemo/Block/myblock.html'
     }) }}
 
 Example
@@ -53,18 +53,18 @@ The main template might look like:
 
             <div class="container">
                 {{ sonata_block_render({ 'type': 'sonata.block.service.template' }, {
-                    'template': 'MyMenuBundle:Block:menu.twig.html'
+                    'template': '@MyMenu/Block/menu.twig.html'
                 }) }}
 
                 <div class="col-4">
                     {{ sonata_block_render({ 'type': 'sonata.block.service.template' }, {
-                        'template': 'MyMenuBundle:Block:navigation.twig.html'
+                        'template': '@MyMenu/Block/navigation.twig.html'
                     }) }}
                 </div>
 
                 <div class="col-6">
                     {{ sonata_block_render({ 'type': 'sonata.block.service.template' }, {
-                        'template': 'MyMenuBundle:Block:content.twig.html'
+                        'template': '@MyMenu/Block/content.twig.html'
                     }) }}
                 </div>
             </div>

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -67,5 +67,5 @@ To use the ``BlockBundle``, add the following lines to your application configur
                 # Some block with different templates
                 #acme.demo.block.demo:
                 #    templates:
-                #       - { name: 'Simple', template: 'AcmeDemoBundle:Block:demo_simple.html.twig' }
-                #       - { name: 'Big',    template: 'AcmeDemoBundle:Block:demo_big.html.twig' }
+                #       - { name: 'Simple', template: '@AcmeDemo/Block/demo_simple.html.twig' }
+                #       - { name: 'Big',    template: '@AcmeDemo/Block/demo_big.html.twig' }

--- a/docs/reference/profiler.rst
+++ b/docs/reference/profiler.rst
@@ -19,4 +19,4 @@ If you want to disable the profiling or configure it, you may add one of the fol
         sonata_block:
             profiler:
                 enabled:        "%kernel.debug%"
-                template:       SonataBlockBundle:Profiler:block.html.twig
+                template:       "@SonataBlock/Profiler/block.html.twig"

--- a/docs/reference/provided_blocks.rst
+++ b/docs/reference/provided_blocks.rst
@@ -26,7 +26,7 @@ This block displays an RSS feed.
 
 When you add this block, specify a title and an RSS URL. Then, the last messages from the RSS feed will be displayed in your block.
 
-Base template is ``SonataBlockBundle:Block:block_core_rss.html.twig`` but you may of course override it.
+Base template is ``@SonataBlock/Block/block_core_rss.html.twig`` but you may of course override it.
 
 MenuBlockService
 ----------------
@@ -47,6 +47,6 @@ Upon configuration, you may set some rendering options (see KNP Doc for those).
 
 Set ``cache_policy`` to private if this menu is dedicated to be in a user part.
 
-A specific menu template is provided as well to render Bootstrap3's side menu, you may use it by setting the ``menu_template`` option to ``SonataBlockBundle:Block:block_side_menu_template.html.twig`` (see the implementation in SonataUserBundle or Sonata's e-commerce suite).
+A specific menu template is provided as well to render Bootstrap3's side menu, you may use it by setting the ``menu_template`` option to ``@SonataBlock/Block/block_side_menu_template.html.twig`` (see the implementation in SonataUserBundle or Sonata's e-commerce suite).
 
 .. _KnpMenuBundle documentation: https://symfony.com/doc/current/bundles/KnpMenuBundle/index.html

--- a/docs/reference/your_first_block.rst
+++ b/docs/reference/your_first_block.rst
@@ -178,7 +178,7 @@ We are almost done! Now, just declare the block as a service:
         <service id="sonata.block.service.rss" class="Sonata\BlockBundle\Block\Service\RssBlockService">
             <tag name="sonata.block" />
             <argument/>
-            <argument type="service" id="templating" />
+            <argument type="service" id="sonata.templating" />
         </service>
 
     .. code-block:: yaml

--- a/docs/reference/your_first_block.rst
+++ b/docs/reference/your_first_block.rst
@@ -51,7 +51,7 @@ In the current tutorial, the default settings are:
         $resolver->setDefaults(array(
             'url'      => false,
             'title'    => 'Insert the rss title',
-            'template' => 'SonataBlockBundle:Block:block_core_rss.html.twig',
+            'template' => '@SonataBlock/Block/block_core_rss.html.twig',
         ));
     }
 

--- a/src/Block/Service/ContainerBlockService.php
+++ b/src/Block/Service/ContainerBlockService.php
@@ -85,7 +85,7 @@ class ContainerBlockService extends AbstractAdminBlockService
             'code' => '',
             'layout' => '{{ CONTENT }}',
             'class' => '',
-            'template' => 'SonataBlockBundle:Block:block_container.html.twig',
+            'template' => '@SonataBlock/Block/block_container.html.twig',
         ]);
     }
 

--- a/src/Block/Service/MenuBlockService.php
+++ b/src/Block/Service/MenuBlockService.php
@@ -137,7 +137,7 @@ class MenuBlockService extends AbstractAdminBlockService
         $resolver->setDefaults([
             'title' => $this->getName(),
             'cache_policy' => 'public',
-            'template' => 'SonataBlockBundle:Block:block_core_menu.html.twig',
+            'template' => '@SonataBlock/Block/block_core_menu.html.twig',
             'menu_name' => '',
             'safe_labels' => false,
             'current_class' => 'active',

--- a/src/Block/Service/RssBlockService.php
+++ b/src/Block/Service/RssBlockService.php
@@ -35,7 +35,7 @@ class RssBlockService extends AbstractAdminBlockService
         $resolver->setDefaults([
             'url' => false,
             'title' => 'Insert the rss title',
-            'template' => 'SonataBlockBundle:Block:block_core_rss.html.twig',
+            'template' => '@SonataBlock/Block/block_core_rss.html.twig',
         ]);
     }
 

--- a/src/Block/Service/TemplateBlockService.php
+++ b/src/Block/Service/TemplateBlockService.php
@@ -56,7 +56,7 @@ class TemplateBlockService extends AbstractAdminBlockService
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'template' => 'SonataBlockBundle:Block:block_template.html.twig',
+            'template' => '@SonataBlock/Block/block_template.html.twig',
         ]);
     }
 

--- a/src/Block/Service/TextBlockService.php
+++ b/src/Block/Service/TextBlockService.php
@@ -58,7 +58,7 @@ class TextBlockService extends AbstractAdminBlockService
     {
         $resolver->setDefaults([
             'content' => 'Insert your custom content here',
-            'template' => 'SonataBlockBundle:Block:block_core_text.html.twig',
+            'template' => '@SonataBlock/Block/block_core_text.html.twig',
         ]);
     }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -71,7 +71,7 @@ class Configuration implements ConfigurationInterface
                     ->fixXmlConfig('container_type', 'container_types')
                     ->children()
                         ->scalarNode('enabled')->defaultValue('%kernel.debug%')->end()
-                        ->scalarNode('template')->defaultValue('SonataBlockBundle:Profiler:block.html.twig')->end()
+                        ->scalarNode('template')->defaultValue('@SonataBlock/Profiler/block.html.twig')->end()
                         ->arrayNode('container_types')
                             ->isRequired()
                             // add default value to well know users of BlockBundle

--- a/src/DependencyInjection/SonataBlockExtension.php
+++ b/src/DependencyInjection/SonataBlockExtension.php
@@ -33,13 +33,13 @@ class SonataBlockExtension extends Extension
 
         $defaultTemplates = [];
         if (isset($bundles['SonataPageBundle'])) {
-            $defaultTemplates['SonataPageBundle:Block:block_container.html.twig'] = 'SonataPageBundle default template';
+            $defaultTemplates['@SonataPage/Block/block_container.html.twig'] = 'SonataPageBundle default template';
         } else {
-            $defaultTemplates['SonataBlockBundle:Block:block_container.html.twig'] = 'SonataBlockBundle default template';
+            $defaultTemplates['@SonataBlock/Block/block_container.html.twig'] = 'SonataBlockBundle default template';
         }
 
         if (isset($bundles['SonataSeoBundle'])) {
-            $defaultTemplates['SonataSeoBundle:Block:block_social_container.html.twig'] = 'SonataSeoBundle (to contain social buttons)';
+            $defaultTemplates['@SonataSeo/Block/block_social_container.html.twig'] = 'SonataSeoBundle (to contain social buttons)';
         }
 
         return new Configuration($defaultTemplates);
@@ -79,11 +79,11 @@ class SonataBlockExtension extends Extension
 
         if ($config['templates']['block_base'] === null) {
             if (isset($bundles['SonataPageBundle'])) {
-                $config['templates']['block_base'] = 'SonataPageBundle:Block:block_base.html.twig';
-                $config['templates']['block_container'] = 'SonataPageBundle:Block:block_container.html.twig';
+                $config['templates']['block_base'] = '@SonataPage/Block/block_base.html.twig';
+                $config['templates']['block_container'] = '@SonataPage/Block/block_container.html.twig';
             } else {
-                $config['templates']['block_base'] = 'SonataBlockBundle:Block:block_base.html.twig';
-                $config['templates']['block_container'] = 'SonataBlockBundle:Block:block_container.html.twig';
+                $config['templates']['block_base'] = '@SonataBlock/Block/block_base.html.twig';
+                $config['templates']['block_container'] = '@SonataBlock/Block/block_container.html.twig';
             }
         }
 

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -12,34 +12,34 @@
         <service id="sonata.block.service.container" class="%sonata.block.service.container.class%">
             <tag name="sonata.block"/>
             <argument>sonata.block.container</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <service id="sonata.block.service.empty" class="%sonata.block.service.empty.class%">
             <tag name="sonata.block"/>
             <argument>sonata.block.empty</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <service id="sonata.block.service.text" class="%sonata.block.service.text.class%">
             <tag name="sonata.block"/>
             <argument>sonata.block.text</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <service id="sonata.block.service.rss" class="%sonata.block.service.rss.class%">
             <tag name="sonata.block"/>
             <argument>sonata.block.rss</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <service id="sonata.block.service.menu" class="%sonata.block.service.menu.class%">
             <tag name="sonata.block"/>
             <argument>sonata.block.menu</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="sonata.block.menu.registry"/>
         </service>
         <service id="sonata.block.service.template" class="%sonata.block.service.template.class%">
             <tag name="sonata.block"/>
             <argument>sonata.block.template</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
     </services>
 </container>

--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="sonata.templating.locator" class="Sonata\BlockBundle\Templating\TemplateLocator">
+            <argument type="service" id="file_locator" />
+            <argument>%kernel.cache_dir%</argument>
+        </service>
+        <service id="sonata.templating.name_parser" class="Sonata\BlockBundle\Templating\TemplateNameParser">
+            <argument type="service" id="kernel" />
+        </service>
+        <service id="sonata.templating" class="Sonata\BlockBundle\Templating\TwigEngine">
+            <argument type="service" id="twig" />
+            <argument type="service" id="sonata.templating.name_parser" />
+            <argument type="service" id="sonata.templating.locator" />
+        </service>
         <service id="sonata.block.manager" class="Sonata\BlockBundle\Block\BlockServiceManager" public="false">
             <argument type="service" id="service_container"/>
             <argument>%kernel.debug%</argument>

--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -38,7 +38,6 @@
             <argument type="service" id="sonata.block.templating.helper"/>
         </service>
         <service id="sonata.block.templating.helper" class="Sonata\BlockBundle\Templating\Helper\BlockHelper">
-            <tag name="templating.helper" alias="sonata_block"/>
             <argument type="service" id="sonata.block.manager"/>
             <argument>%sonata_block.cache_blocks%</argument>
             <argument type="service" id="sonata.block.renderer"/>

--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -2,16 +2,16 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sonata.templating.locator" class="Sonata\BlockBundle\Templating\TemplateLocator">
-            <argument type="service" id="file_locator" />
+            <argument type="service" id="file_locator"/>
             <argument>%kernel.cache_dir%</argument>
         </service>
         <service id="sonata.templating.name_parser" class="Sonata\BlockBundle\Templating\TemplateNameParser">
-            <argument type="service" id="kernel" />
+            <argument type="service" id="kernel"/>
         </service>
         <service id="sonata.templating" class="Sonata\BlockBundle\Templating\TwigEngine">
-            <argument type="service" id="twig" />
-            <argument type="service" id="sonata.templating.name_parser" />
-            <argument type="service" id="sonata.templating.locator" />
+            <argument type="service" id="twig"/>
+            <argument type="service" id="sonata.templating.name_parser"/>
+            <argument type="service" id="sonata.templating.locator"/>
         </service>
         <service id="sonata.block.manager" class="Sonata\BlockBundle\Block\BlockServiceManager" public="false">
             <argument type="service" id="service_container"/>

--- a/src/Resources/config/exception.xml
+++ b/src/Resources/config/exception.xml
@@ -23,11 +23,11 @@
         </service>
         <!-- exception renderers -->
         <service id="sonata.block.exception.renderer.inline" class="Sonata\BlockBundle\Exception\Renderer\InlineRenderer" public="true">
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument>@SonataBlock/Block/block_exception.html.twig</argument>
         </service>
         <service id="sonata.block.exception.renderer.inline_debug" class="Sonata\BlockBundle\Exception\Renderer\InlineDebugRenderer" public="true">
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument>@SonataBlock/Block/block_exception_debug.html.twig</argument>
             <argument>%kernel.debug%</argument>
             <argument>true</argument>

--- a/src/Resources/config/exception.xml
+++ b/src/Resources/config/exception.xml
@@ -24,11 +24,11 @@
         <!-- exception renderers -->
         <service id="sonata.block.exception.renderer.inline" class="Sonata\BlockBundle\Exception\Renderer\InlineRenderer" public="true">
             <argument type="service" id="templating"/>
-            <argument>SonataBlockBundle:Block:block_exception.html.twig</argument>
+            <argument>@SonataBlock/Block/block_exception.html.twig</argument>
         </service>
         <service id="sonata.block.exception.renderer.inline_debug" class="Sonata\BlockBundle\Exception\Renderer\InlineDebugRenderer" public="true">
             <argument type="service" id="templating"/>
-            <argument>SonataBlockBundle:Block:block_exception_debug.html.twig</argument>
+            <argument>@SonataBlock/Block/block_exception_debug.html.twig</argument>
             <argument>%kernel.debug%</argument>
             <argument>true</argument>
         </service>

--- a/src/Resources/views/Block/block_exception_debug.html.twig
+++ b/src/Resources/views/Block/block_exception_debug.html.twig
@@ -19,6 +19,6 @@ file that was distributed with this source code.
             <link href="{{ asset('bundles/framework/css/exception_layout.css') }}" rel="stylesheet" type="text/css" media="all" />
             <link href="{{ asset('bundles/framework/css/exception.css') }}" rel="stylesheet" type="text/css" media="all" />
         {% endif %}
-        {% include 'TwigBundle:Exception:exception.html.twig' %}
+        {% include '@Twig/Exception/exception.html.twig' %}
     </div>
 {% endblock %}

--- a/src/Resources/views/Block/block_template.html.twig
+++ b/src/Resources/views/Block/block_template.html.twig
@@ -17,7 +17,7 @@ file that was distributed with this source code.
 
     <pre>
         {%- verbatim -%}
-{# file: 'MyBundle:Block:my_block_feature_1.html.twig' #}
+{# file: '@My/Block/my_block_feature_1.html.twig' #}
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
@@ -37,7 +37,7 @@ file that was distributed with this source code.
     <pre>
 {%- verbatim -%}
 {{ sonata_block_render({ 'type': 'sonata.block.service.template' }, {
-    'template': 'MyBundle:Block:my_block_feature_1.html.twig',
+    'template': '@My/Block/my_block_feature_1.html.twig',
 }) }}
 {%- endverbatim -%}
     </pre>

--- a/src/Resources/views/Profiler/block.html.twig
+++ b/src/Resources/views/Profiler/block.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     <div class="sf-toolbar-block">

--- a/src/Templating/EngineInterface.php
+++ b/src/Templating/EngineInterface.php
@@ -15,5 +15,4 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface as TemplatingEngin
 
 interface EngineInterface extends TemplatingEngineInterface
 {
-
 }

--- a/src/Templating/EngineInterface.php
+++ b/src/Templating/EngineInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Templating;
+
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface as TemplatingEngineInterface;
+
+interface EngineInterface extends TemplatingEngineInterface
+{
+
+}

--- a/src/Templating/TemplateLocator.php
+++ b/src/Templating/TemplateLocator.php
@@ -18,5 +18,4 @@ use Symfony\Bundle\FrameworkBundle\Templating\Loader\TemplateLocator as Framewor
  */
 class TemplateLocator extends FrameworkTemplateLocator
 {
-
 }

--- a/src/Templating/TemplateLocator.php
+++ b/src/Templating/TemplateLocator.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Templating;
+
+use Symfony\Bundle\FrameworkBundle\Templating\Loader\TemplateLocator as FrameworkTemplateLocator;
+
+/**
+ * @deprecated
+ */
+class TemplateLocator extends FrameworkTemplateLocator
+{
+
+}

--- a/src/Templating/TemplateLocator.php
+++ b/src/Templating/TemplateLocator.php
@@ -14,7 +14,7 @@ namespace Sonata\BlockBundle\Templating;
 use Symfony\Bundle\FrameworkBundle\Templating\Loader\TemplateLocator as FrameworkTemplateLocator;
 
 /**
- * @deprecated
+ * @deprecated since 3.9, to be removed with 4.0.
  */
 class TemplateLocator extends FrameworkTemplateLocator
 {

--- a/src/Templating/TemplateNameParser.php
+++ b/src/Templating/TemplateNameParser.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Templating;
+
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser as FrameworkTemplateNameParser;
+
+/**
+ * @deprecated
+ */
+class TemplateNameParser extends FrameworkTemplateNameParser
+{
+
+}

--- a/src/Templating/TemplateNameParser.php
+++ b/src/Templating/TemplateNameParser.php
@@ -18,5 +18,4 @@ use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser as FrameworkTem
  */
 class TemplateNameParser extends FrameworkTemplateNameParser
 {
-
 }

--- a/src/Templating/TemplateNameParser.php
+++ b/src/Templating/TemplateNameParser.php
@@ -14,7 +14,7 @@ namespace Sonata\BlockBundle\Templating;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser as FrameworkTemplateNameParser;
 
 /**
- * @deprecated
+ * @deprecated since 3.9, to be removed with 4.0.
  */
 class TemplateNameParser extends FrameworkTemplateNameParser
 {

--- a/src/Templating/TwigEngine.php
+++ b/src/Templating/TwigEngine.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Templating;
+
+use Symfony\Bundle\TwigBundle\TwigEngine as BaseTwigEngine;
+
+class TwigEngine extends BaseTwigEngine implements EngineInterface
+{
+
+}

--- a/src/Templating/TwigEngine.php
+++ b/src/Templating/TwigEngine.php
@@ -15,5 +15,4 @@ use Symfony\Bundle\TwigBundle\TwigEngine as BaseTwigEngine;
 
 class TwigEngine extends BaseTwigEngine implements EngineInterface
 {
-
 }

--- a/src/Test/FakeTemplating.php
+++ b/src/Test/FakeTemplating.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\BlockBundle\Test;
 
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Sonata\BlockBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/tests/Block/Service/MenuBlockServiceTest.php
+++ b/tests/Block/Service/MenuBlockServiceTest.php
@@ -122,7 +122,7 @@ class MenuBlockServiceTest extends AbstractBlockServiceTestCase
         $this->assertSettings([
             'title' => 'sonata.page.block.menu',
             'cache_policy' => 'public',
-            'template' => 'SonataBlockBundle:Block:block_core_menu.html.twig',
+            'template' => '@SonataBlock/Block/block_core_menu.html.twig',
             'menu_name' => '',
             'safe_labels' => false,
             'current_class' => 'active',

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -20,8 +20,8 @@ class ConfigurationTest extends TestCase
     public function testOptions()
     {
         $defaultTemplates = [
-            'SonataPageBundle:Block:block_container.html.twig' => 'SonataPageBundle template',
-            'SonataSeoBundle:Block:block_social_container.html.twig' => 'SonataSeoBundle (to contain social buttons)',
+            '@SonataPage/Block/block_container.html.twig' => 'SonataPageBundle template',
+            '@SonataSeo/Block/block_social_container.html.twig' => 'SonataSeoBundle (to contain social buttons)',
         ];
 
         $processor = new Processor();
@@ -37,7 +37,7 @@ class ConfigurationTest extends TestCase
             ],
             'profiler' => [
                 'enabled' => '%kernel.debug%',
-                'template' => 'SonataBlockBundle:Profiler:block.html.twig',
+                'template' => '@SonataBlock/Profiler/block.html.twig',
                 'container_types' => [
                     0 => 'sonata.block.service.container',
                     1 => 'sonata.page.block.container',
@@ -103,8 +103,8 @@ class ConfigurationTest extends TestCase
         $this->expectExceptionMessage('Invalid configuration for path "sonata_block": You cannot have different config options for sonata_block.profiler.container_types and sonata_block.container.types; the first one is deprecated, in case of doubt use the latter');
 
         $defaultTemplates = [
-            'SonataPageBundle:Block:block_container.html.twig' => 'SonataPageBundle template',
-            'SonataSeoBundle:Block:block_social_container.html.twig' => 'SonataSeoBundle (to contain social buttons)',
+            '@SonataPage/Block/block_container.html.twig' => 'SonataPageBundle template',
+            '@SonataSeo/Block/block_social_container.html.twig' => 'SonataSeoBundle (to contain social buttons)',
         ];
 
         $processor = new Processor();


### PR DESCRIPTION
I am targeting this branch, because this is backward compatible feature.

See #456

## Changelog

```markdown
### Added
- Added `symfony/asset` and `symfony/templating` dependencies
- Added new service `sonata.templating` for use in place of `templating`

### Changed
- Referencing templates using Twig namespaced syntax

### Removed
- Removed tag `templating.helper` from `sonata.block.templating.helper` service
```

## Subject

This is first step to switching from `Templating Component` to using `Twig` directly. The following two steps are described in #456. This PR will allow to run `SonataBlockBundle` without activating templating extension in `framework`.

If this PR will be accepted, all other sonata bundles, that use SonataBlockBundle, could be updated too: services will have to use `sonata.templating` service instead of `templating` and templates must be referenced using Twig namespaced syntax
  
  