### PR TITLE
Make services public

### DIFF
--- a/src/Resources/config/exception.xml
+++ b/src/Resources/config/exception.xml
@@ -13,25 +13,25 @@
             <argument type="collection"/>
         </service>
         <!-- exception filters -->
-        <service id="sonata.block.exception.filter.keep_none" class="Sonata\BlockBundle\Exception\Filter\KeepNoneFilter"/>
-        <service id="sonata.block.exception.filter.keep_all" class="Sonata\BlockBundle\Exception\Filter\KeepAllFilter"/>
-        <service id="sonata.block.exception.filter.debug_only" class="Sonata\BlockBundle\Exception\Filter\DebugOnlyFilter">
+        <service id="sonata.block.exception.filter.keep_none" class="Sonata\BlockBundle\Exception\Filter\KeepNoneFilter" public="true"/>
+        <service id="sonata.block.exception.filter.keep_all" class="Sonata\BlockBundle\Exception\Filter\KeepAllFilter" public="true"/>
+        <service id="sonata.block.exception.filter.debug_only" class="Sonata\BlockBundle\Exception\Filter\DebugOnlyFilter" public="true">
             <argument>%kernel.debug%</argument>
         </service>
-        <service id="sonata.block.exception.filter.ignore_block_exception" class="Sonata\BlockBundle\Exception\Filter\IgnoreClassFilter">
+        <service id="sonata.block.exception.filter.ignore_block_exception" class="Sonata\BlockBundle\Exception\Filter\IgnoreClassFilter" public="true">
             <argument>Sonata\BlockBundle\Exception\BlockExceptionInterface</argument>
         </service>
         <!-- exception renderers -->
-        <service id="sonata.block.exception.renderer.inline" class="Sonata\BlockBundle\Exception\Renderer\InlineRenderer">
+        <service id="sonata.block.exception.renderer.inline" class="Sonata\BlockBundle\Exception\Renderer\InlineRenderer" public="true">
             <argument type="service" id="templating"/>
             <argument>SonataBlockBundle:Block:block_exception.html.twig</argument>
         </service>
-        <service id="sonata.block.exception.renderer.inline_debug" class="Sonata\BlockBundle\Exception\Renderer\InlineDebugRenderer">
+        <service id="sonata.block.exception.renderer.inline_debug" class="Sonata\BlockBundle\Exception\Renderer\InlineDebugRenderer" public="true">
             <argument type="service" id="templating"/>
             <argument>SonataBlockBundle:Block:block_exception_debug.html.twig</argument>
             <argument>%kernel.debug%</argument>
             <argument>true</argument>
         </service>
-        <service id="sonata.block.exception.renderer.throw" class="Sonata\BlockBundle\Exception\Renderer\MonkeyThrowRenderer"/>
+        <service id="sonata.block.exception.renderer.throw" class="Sonata\BlockBundle\Exception\Renderer\MonkeyThrowRenderer" public="true"/>
     </services>
 </container>


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

```markdown
### Changed
- Make block exception filters and renderers as public services
```

## Subject

Error occured when [StrategyManager](https://github.com/sonata-project/SonataBlockBundle/blob/3.x/src/Exception/Strategy/StrategyManager.php) tries to load block exception filters or renderers directly from container, because services are private by default since Symfony 3.4