### PR TITLE
Fix compat with Symfony 2.8 definition

### DIFF
--- a/src/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -40,7 +40,12 @@ class TweakCompilerPass implements CompilerPassInterface
 
             // Replace empty block id with service id
             if (empty($arguments) || 0 == strlen($arguments[0])) {
-                $definition->setArgument(0, $id);
+                // NEXT_MAJOR: Remove the condition when Symfony 2.8 support will be dropped.
+                if (method_exists($definition, 'setArgument')) {
+                    $definition->setArgument(0, $id);
+                } else {
+                    $definition->replaceArgument(0, $id);
+                }
             } elseif ($id != $arguments[0] && 0 !== strpos(
                 $container->getParameterBag()->resolveValue($definition->getClass()),
                 'Sonata\\BlockBundle\\Block\\Service\\'


### PR DESCRIPTION
I am targeting this branch, because bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataBlockBundle/pull/410#issuecomment-355290382

## Changelog

```markdown
### Fixed
- Definition argument incompatibilities with Symfony 2.8
```
