### PR TITLE
add one more dependency in composer for creating symfony-recipe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "sonata-project/core-bundle": "^3.4",
         "symfony/form": "^2.8 || ^3.2 || ^4.0",
         "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
+        "symfony/templating": "^2.8 || ^3.2 || ^4.0",
         "symfony/twig-bundle": "^2.8 || ^3.2 || ^4.0",
         "twig/twig": "^1.34 || ^2.0"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because we are creating recipe for 3.x version.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fix for https://github.com/symfony/recipes-contrib/pull/235

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- added symfony/templating dependency to composer for using symfony recipes
```

  