### PR TITLE
Add tag templating.helper back to sonata.block.templating.helper service

### DIFF
--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -38,6 +38,7 @@
             <argument type="service" id="sonata.block.templating.helper"/>
         </service>
         <service id="sonata.block.templating.helper" class="Sonata\BlockBundle\Templating\Helper\BlockHelper">
+            <tag name="templating.helper" alias="sonata_block"/>
             <argument type="service" id="sonata.block.manager"/>
             <argument>%sonata_block.cache_blocks%</argument>
             <argument type="service" id="sonata.block.renderer"/>


### PR DESCRIPTION
## Changelog

```markdown
### Added
- Add tag `templating.helper` back to `sonata.block.templating.helper` service
```

## Subject

With `templating.helper` tag removal in #457, ability to use public functions of a helper removed too. This PR reverts this feature back.