### PR TITLE
Update installation documentation for Symfony Flex

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -9,11 +9,29 @@ The easiest way to install ``SonataBlockBundle`` is to require it with Composer:
 
 .. code-block:: bash
 
-    $ php composer.phar require sonata-project/block-bundle
+    $ composer require sonata-project/block-bundle
 
 Alternatively, you could add a dependency into your `composer.json` file directly.
 
-Now, enable the bundle in the kernel:
+Now, enable the bundle in ``bundles.php`` file:
+
+.. code-block:: php
+
+    <?php
+
+    // config/bundles.php
+
+    return [
+        //...
+        Knp\Bundle\MenuBundle\KnpMenuBundle::class => ['all' => true],
+        Sonata\CoreBundle\SonataCoreBundle::class => ['all' => true],
+        Sonata\BlockBundle\SonataBlockBundle::class => ['all' => true],
+    ];
+
+.. note::
+    If you are not using Symfony Flex, you should enable bundles in your
+    ``AppKernel.php``.
+
 
 .. code-block:: php
 
@@ -45,7 +63,7 @@ To use the ``BlockBundle``, add the following lines to your application configur
 
     .. code-block:: yaml
 
-        # app/config/config.yml
+        # config/packages/sonata.yaml
 
         sonata_block:
             default_contexts: [sonata_page_bundle]
@@ -69,3 +87,7 @@ To use the ``BlockBundle``, add the following lines to your application configur
                 #    templates:
                 #       - { name: 'Simple', template: '@AcmeDemo/Block/demo_simple.html.twig' }
                 #       - { name: 'Big',    template: '@AcmeDemo/Block/demo_big.html.twig' }
+
+.. note::
+    If you are not using Symfony Flex, this configuration should be added
+    to ``app/config/config.yml``.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I am updating documentation for Symfony Flex.


## Subject

Updating documentation to adopt new flex structure.