### PR TITLE
Added more options to blocks

### DIFF
--- a/src/Block/Service/RssBlockService.php
+++ b/src/Block/Service/RssBlockService.php
@@ -34,7 +34,10 @@ class RssBlockService extends AbstractAdminBlockService
     {
         $resolver->setDefaults([
             'url' => false,
-            'title' => 'Insert the rss title',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-rss-square',
+            'class' => null,
             'template' => '@SonataBlock/Block/block_core_rss.html.twig',
         ]);
     }
@@ -51,8 +54,20 @@ class RssBlockService extends AbstractAdminBlockService
                     'label' => 'form.label_url',
                 ]],
                 ['title', TextType::class, [
-                    'required' => false,
                     'label' => 'form.label_title',
+                    'required' => false,
+                ]],
+                ['translation_domain', TextType::class, [
+                    'label' => 'form.label_translation_domain',
+                    'required' => false,
+                ]],
+                ['icon', TextType::class, [
+                    'label' => 'form.label_icon',
+                    'required' => false,
+                ]],
+                ['class', TextType::class, [
+                    'label' => 'form.label_class',
+                    'required' => false,
                 ]],
             ],
             'translation_domain' => 'SonataBlockBundle',

--- a/src/Resources/translations/SonataBlockBundle.de.xliff
+++ b/src/Resources/translations/SonataBlockBundle.de.xliff
@@ -82,6 +82,14 @@
                 <source>form.label_menu_template</source>
                 <target>Menü Template</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Übersetzungsdatei</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icon</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataBlockBundle.en.xliff
+++ b/src/Resources/translations/SonataBlockBundle.en.xliff
@@ -82,6 +82,14 @@
                 <source>form.label_menu_template</source>
                 <target>Menu Template</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Translation domain</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icon</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataBlockBundle.fr.xliff
+++ b/src/Resources/translations/SonataBlockBundle.fr.xliff
@@ -82,6 +82,14 @@
                 <source>form.label_menu_template</source>
                 <target>Template du menu</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Domaine de traduction</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icône</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/views/Block/block_core_rss.html.twig
+++ b/src/Resources/views/Block/block_core_rss.html.twig
@@ -11,16 +11,35 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    <h3 class="sonata-feed-title">{{ settings.title }}</h3>
-
-    <div class="sonata-feeds-container">
-        {% for feed in feeds %}
-            <div>
-                <strong><a href="{{ feed.link}}" rel="nofollow" title="{{ feed.title }}">{{ feed.title }}</a></strong>
-                <div>{{ feed.description|raw }}</div>
+    <div class="panel panel-default {{ settings.class }}">
+        {% if settings.title is not empty %}
+            <div class="panel-heading">
+                <h4 class="panel-title">
+                    {% if settings.icon %}
+                        <i class="{{ settings.icon }}" aria-hidden="true"></i>
+                    {% endif %}
+                    {% if settings.translation_domain %}
+                        {{ settings.title|trans({}, settings.translation_domain) }}
+                    {% else %}
+                        {{ settings.title }}
+                    {% endif %}
+                </h4>
             </div>
-        {% else %}
-                No feeds available.
-        {% endfor %}
+        {% endif %}
+
+        <div class="panel-body">
+            <div class="media">
+                {% for feed in feeds %}
+                    <div class="media-body">
+                        <h5 class="media-heading">
+                            <a href="{{ feed.link }}" rel="nofollow" title="{{ feed.title }}">{{ feed.title }}</a>
+                        </h5>
+                        {{ feed.description|raw }}
+                    </div>
+                {% else %}
+                    No feeds available.
+                {% endfor %}
+            </div>
+        </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature is BC (if you ignore the html changes).

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
 - added title translation domain option to `RssBlockService`
 - added icon option to `RssBlockService`
 - added class option to `RssBlockService`

### Removed
 - Removed default title from `RssBlockService`
 - Redesign `RssBlockService` template
```

