### PR TITLE
Removed old PHPUnit 4 code

### DIFF
--- a/src/Test/AbstractBlockServiceTestCase.php
+++ b/src/Test/AbstractBlockServiceTestCase.php
@@ -19,13 +19,6 @@ use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/*
- * NEXT_MAJOR: remove check when dropping support for PHPUnit 4
- */
-if (!class_exists(TestCase::class)) {
-    class_alias('\PHPUnit_Framework_TestCase', TestCase::class);
-}
-
 /**
  * Abstract test class for block service tests.
  *


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch for tests.

<!--
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - Removed support for PHPUnit 4 in AbstractBlockServiceTestCase
```

## Subject

PHPUnit 4 is long dead.