### PR TITLE
Make services public

### DIFF
--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -13,7 +13,7 @@
             <argument type="service" id="sonata.templating.name_parser"/>
             <argument type="service" id="sonata.templating.locator"/>
         </service>
-        <service id="sonata.block.manager" class="Sonata\BlockBundle\Block\BlockServiceManager" public="false">
+        <service id="sonata.block.manager" class="Sonata\BlockBundle\Block\BlockServiceManager" public="true">
             <argument type="service" id="service_container"/>
             <argument>%kernel.debug%</argument>
             <argument type="service" id="logger" on-invalid="ignore"/>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC fix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- sonata.block.manager is public
```
