### PR TITLE
handle correctly deprecated setDefaultSettings on blocks

### DIFF
--- a/src/Block/BlockContextManager.php
+++ b/src/Block/BlockContextManager.php
@@ -257,25 +257,19 @@ class BlockContextManager implements BlockContextManagerInterface
 
         $service = $this->blockService->get($block);
 
-        /* use new interface method whenever possible */
-        if (method_exists($service, 'configureSettings')) {
-            $service->configureSettings($optionsResolver);
-        } else {
-            $service->setDefaultSettings($optionsResolver);
-        }
-
         // Caching method reflection
+        // NEXT_MAJOR: Remove everything here
         $serviceClass = get_class($service);
         if (!isset($this->reflectionCache[$serviceClass])) {
             $reflector = new \ReflectionMethod($service, 'setDefaultSettings');
-            $isOldOverwritten = 'Sonata\BlockBundle\Block\AbstractBlockService' !== $reflector->getDeclaringClass()->getName();
+            $isOldOverwritten = get_class($service) === $reflector->getDeclaringClass()->getName();
 
             // Prevention for service classes implementing directly the interface and not extends the new base class
             if (!method_exists($service, 'configureSettings')) {
                 $isNewOverwritten = false;
             } else {
                 $reflector = new \ReflectionMethod($service, 'configureSettings');
-                $isNewOverwritten = 'Sonata\BlockBundle\Block\AbstractBlockService' !== $reflector->getDeclaringClass()->getName();
+                $isNewOverwritten = get_class($service) === $reflector->getDeclaringClass()->getName();
             }
 
             $this->reflectionCache[$serviceClass] = [
@@ -284,6 +278,7 @@ class BlockContextManager implements BlockContextManagerInterface
             ];
         }
 
+        // NEXT_MAJOR: Keep Only else case
         if ($this->reflectionCache[$serviceClass]['isOldOverwritten'] && !$this->reflectionCache[$serviceClass]['isNewOverwritten']) {
             @trigger_error(
                 'The Sonata\BlockBundle\Block\BlockServiceInterface::setDefaultSettings() method is deprecated'
@@ -291,6 +286,9 @@ class BlockContextManager implements BlockContextManagerInterface
                 .' This method will be added to the BlockServiceInterface with SonataBlockBundle 4.0.',
                 E_USER_DEPRECATED
             );
+            $service->setDefaultSettings($optionsResolver);
+        } else {
+            $service->configureSettings($optionsResolver);
         }
 
         return $optionsResolver->resolve($settings);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/issues/3884
Closes #149 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Now the deprecated `setDefaultSettings` for blocks is handled correctly. You should avoid using it in favor of `configureSettings` but it will work and show the deprecated message.
```

## Subject

<!-- Describe your Pull Request content here -->
I just tried the code here: https://github.com/sonata-project/SonataAdminBundle/issues/3884
and found the problem.

It is not nice to compare with a class that might change (in this case we changed it, and broke it again). 
Probably no one cares now for this, but it is nice to have old code work instead of throwing random deprecations