### PR TITLE
Fix TTL calculation in BlockRenderer

### DIFF
--- a/src/Block/BlockRenderer.php
+++ b/src/Block/BlockRenderer.php
@@ -141,7 +141,9 @@ class BlockRenderer implements BlockRendererInterface
     {
         // a response exists, use it
         if ($this->lastResponse && $this->lastResponse->isCacheable()) {
-            $response->setTtl($this->lastResponse->getTtl());
+            if($this->lastResponse->getTtl()<$response->getTtl()) {
+                $response->setTtl($this->lastResponse->getTtl());
+            }
             $response->setPublic();
         } elseif ($this->lastResponse) { // not cacheable
             $response->setPrivate();

--- a/src/Block/BlockRenderer.php
+++ b/src/Block/BlockRenderer.php
@@ -141,7 +141,7 @@ class BlockRenderer implements BlockRendererInterface
     {
         // a response exists, use it
         if ($this->lastResponse && $this->lastResponse->isCacheable()) {
-            if($this->lastResponse->getTtl()<$response->getTtl()) {
+            if($this->lastResponse->getTtl() < $response->getTtl()) {
                 $response->setTtl($this->lastResponse->getTtl());
             }
             $response->setPublic();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Patch
- Fixed TTL calculation in `BlockRenderer::addMetaInformation`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

<!-- Describe your Pull Request content here -->

Hi,
I hope I understand correctly author intentions but...
Without this IF all children got TTL from first child.
For example if you have footer container with 2 child:

- sonata.block.service.text (default TTL: 86400, sonata.cache.noop)
- custom.sonata.media.block.gallery (TTL: 30, sonata.cache.memcached)

addMetaInformation function overwrite custom.sonata.media.block.gallery TTL to 86400

Best regards and thanks for your hard work with whole project.