### PR TITLE
Added "debug:block" command alias

### DIFF
--- a/src/Command/DebugBlocksCommand.php
+++ b/src/Command/DebugBlocksCommand.php
@@ -24,7 +24,7 @@ class DebugBlocksCommand extends BaseCommand
     public function configure()
     {
         // NEXT_MAJOR: Switch name and alias
-        $this->setAliases(['debug:block']);
+        $this->setAliases(['debug:sonata:block']);
         $this->setName('sonata:block:debug');
         $this->setDescription('Debug all blocks available, show default settings of each block');
 

--- a/src/Command/DebugBlocksCommand.php
+++ b/src/Command/DebugBlocksCommand.php
@@ -23,6 +23,8 @@ class DebugBlocksCommand extends BaseCommand
      */
     public function configure()
     {
+        // NEXT_MAJOR: Switch name and alias
+        $this->setAliases(['debug:block']);
         $this->setName('sonata:block:debug');
         $this->setDescription('Debug all blocks available, show default settings of each block');
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `debug:sonata:block` command alias for `DebugBlocksCommand`
```

## Subject

You should use the `debug:` prefix for debug commands.
