### PR TITLE
configureOptions to configureSettings

### DIFF
--- a/docs/reference/your_first_block.rst
+++ b/docs/reference/your_first_block.rst
@@ -46,7 +46,7 @@ In the current tutorial, the default settings are:
 
     <?php
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'url'      => false,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because docs.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs #497

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

Use `configureSettings()` instead of `configureOptions()`
