### PR TITLE
Deprecate block assets

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,15 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.12 to 3.x
+=======================
+
+## Deprecate block assets 
+
+Deprecated `BlockServiceInterface::getJavascripts` and `BlockServiceInterface::getStylesheets`. 
+Move your block assets to the template.
+
+
 UPGRADE FROM 3.8 to 3.9
 =======================
 

--- a/src/Block/BlockServiceInterface.php
+++ b/src/Block/BlockServiceInterface.php
@@ -56,6 +56,8 @@ interface BlockServiceInterface
     public function load(BlockInterface $block);
 
     /**
+     * @deprecated since 3.x, to be removed in 4.0
+     *
      * @param string $media
      *
      * @return array
@@ -63,6 +65,8 @@ interface BlockServiceInterface
     public function getJavascripts($media);
 
     /**
+     * @deprecated since 3.x, to be removed in 4.0
+     *
      * @param string $media
      *
      * @return array

--- a/src/Templating/Helper/BlockHelper.php
+++ b/src/Templating/Helper/BlockHelper.php
@@ -335,6 +335,20 @@ class BlockHelper extends Helper
             'css' => $service->getStylesheets('all'),
         ];
 
+        if (\count($assets['js']) > 0) {
+            @trigger_error(
+                'Defining javascripts assets inside a block is deprecated since 3.x and will be removed in 4.0',
+                E_USER_DEPRECATED
+            );
+        }
+
+        if (\count($assets['css']) > 0) {
+            @trigger_error(
+                'Defining css assets inside a block is deprecated since 3.x and will be removed in 4.0',
+                E_USER_DEPRECATED
+            );
+        }
+
         if ($blockContext->getBlock()->hasChildren()) {
             $iterator = new \RecursiveIteratorIterator(new RecursiveBlockIterator($blockContext->getBlock()->getChildren()));
 

--- a/tests/Templating/Helper/BlockHelperTest.php
+++ b/tests/Templating/Helper/BlockHelperTest.php
@@ -36,6 +36,9 @@ class BlockHelperTest extends TestCase
         $this->assertEquals('', $helper->renderEvent('my.event'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testRenderEventWithListeners()
     {
         $blockService = $this->createMock('Sonata\BlockBundle\Block\BlockServiceInterface');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because deprecations are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `BlockServiceInterface::getJavascripts`
- Deprecated `BlockServiceInterface::getStylesheets`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

Asset management shouln't be part of the PHP logic. You should move this stuff to your templates or your JavaScript AMD.
