### PR TITLE
Allow autowiring blocks

### DIFF
--- a/src/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -93,13 +93,19 @@ class TweakCompilerPass implements CompilerPassInterface
 
         // Replace empty block id with service id
         if (empty($arguments) || 0 == \strlen($arguments[0])) {
-            // NEXT_MAJOR: Remove the condition when Symfony 2.8 support will be dropped.
+            // NEXT_MAJOR: Remove the if block when Symfony 2.8 support will be dropped.
             if (method_exists($definition, 'setArgument')) {
                 $definition->setArgument(0, $id);
-            } else {
-                $definition->replaceArgument(0, $id);
+
+                return;
             }
-        } elseif ($id != $arguments[0] && 0 !== strpos(
+
+            $definition->replaceArgument(0, $id);
+
+            return;
+        }
+
+        if ($id != $arguments[0] && 0 !== strpos(
             $container->getParameterBag()->resolveValue($definition->getClass()),
             'Sonata\\BlockBundle\\Block\\Service\\'
         )) {

--- a/src/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -13,6 +13,7 @@ namespace Sonata\BlockBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -36,25 +37,8 @@ class TweakCompilerPass implements CompilerPassInterface
             $definition = $container->getDefinition($id);
             $definition->setPublic(true);
 
-            $arguments = $definition->getArguments();
-
-            // Replace empty block id with service id
-            if (empty($arguments) || 0 == \strlen($arguments[0])) {
-                // NEXT_MAJOR: Remove the condition when Symfony 2.8 support will be dropped.
-                if (method_exists($definition, 'setArgument')) {
-                    $definition->setArgument(0, $id);
-                } else {
-                    $definition->replaceArgument(0, $id);
-                }
-            } elseif ($id != $arguments[0] && 0 !== strpos(
-                $container->getParameterBag()->resolveValue($definition->getClass()),
-                'Sonata\\BlockBundle\\Block\\Service\\'
-            )) {
-                // NEXT_MAJOR: Remove deprecation notice
-                @trigger_error(
-                    sprintf('Using service id %s different from block id %s is deprecated since 3.3 and will be removed in 4.0.', $id, $arguments[0]),
-                    E_USER_DEPRECATED
-                );
+            if (!$definition->isAutowired()) {
+                $this->replaceBlockName($container, $definition, $id);
             }
 
             $manager->addMethodCall('add', [$id, $id, isset($parameters[$id]) ? $parameters[$id]['contexts'] : []]);
@@ -97,6 +81,33 @@ class TweakCompilerPass implements CompilerPassInterface
             if (\count($settings['settings']) > 0) {
                 $definition->addMethodCall('addSettingsByClass', [$class, $settings['settings'], true]);
             }
+        }
+    }
+
+    /**
+     * Replaces the empty service name with the service id.
+     */
+    private function replaceBlockName(ContainerBuilder $container, Definition $definition, $id)
+    {
+        $arguments = $definition->getArguments();
+
+        // Replace empty block id with service id
+        if (empty($arguments) || 0 == \strlen($arguments[0])) {
+            // NEXT_MAJOR: Remove the condition when Symfony 2.8 support will be dropped.
+            if (method_exists($definition, 'setArgument')) {
+                $definition->setArgument(0, $id);
+            } else {
+                $definition->replaceArgument(0, $id);
+            }
+        } elseif ($id != $arguments[0] && 0 !== strpos(
+            $container->getParameterBag()->resolveValue($definition->getClass()),
+            'Sonata\\BlockBundle\\Block\\Service\\'
+        )) {
+            // NEXT_MAJOR: Remove deprecation notice
+            @trigger_error(
+                sprintf('Using service id %s different from block id %s is deprecated since 3.3 and will be removed in 4.0.', $id, $arguments[0]),
+                E_USER_DEPRECATED
+            );
         }
     }
 }

--- a/tests/DependencyInjection/Compiler/TweakCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/TweakCompilerPassTest.php
@@ -50,11 +50,11 @@ final class TweakCompilerPassTest extends TestCase
         $blockDefinition->addTag('sonata.block');
         $blockDefinition->setAutoconfigured(true);
 
-        $managerDefintion = $this->createMock(Definition::class);
-        $managerDefintion->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
+        $managerDefinition = $this->createMock(Definition::class);
+        $managerDefinition->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
 
         $this->container->setDefinition('acme.block.service', $blockDefinition);
-        $this->container->setDefinition('sonata.block.manager', $managerDefintion);
+        $this->container->setDefinition('sonata.block.manager', $managerDefinition);
 
         $pass = new TweakCompilerPass();
         $pass->process($this->container);
@@ -66,11 +66,11 @@ final class TweakCompilerPassTest extends TestCase
         $blockDefinition = new Definition(null, ['acme.block.service']);
         $blockDefinition->addTag('sonata.block');
 
-        $managerDefintion = $this->createMock(Definition::class);
-        $managerDefintion->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
+        $managerDefinition = $this->createMock(Definition::class);
+        $managerDefinition->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
 
         $this->container->setDefinition('acme.block.service', $blockDefinition);
-        $this->container->setDefinition('sonata.block.manager', $managerDefintion);
+        $this->container->setDefinition('sonata.block.manager', $managerDefinition);
 
         $pass = new TweakCompilerPass();
         $pass->process($this->container);
@@ -85,11 +85,11 @@ final class TweakCompilerPassTest extends TestCase
         $blockDefinition = new Definition(null, ['acme.block.service.name']);
         $blockDefinition->addTag('sonata.block');
 
-        $managerDefintion = $this->createMock(Definition::class);
-        $managerDefintion->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
+        $managerDefinition = $this->createMock(Definition::class);
+        $managerDefinition->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
 
         $this->container->setDefinition('acme.block.service', $blockDefinition);
-        $this->container->setDefinition('sonata.block.manager', $managerDefintion);
+        $this->container->setDefinition('sonata.block.manager', $managerDefinition);
 
         $pass = new TweakCompilerPass();
         $pass->process($this->container);
@@ -101,11 +101,11 @@ final class TweakCompilerPassTest extends TestCase
         $blockDefinition = new Definition(null, ['']);
         $blockDefinition->addTag('sonata.block');
 
-        $managerDefintion = $this->createMock(Definition::class);
-        $managerDefintion->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
+        $managerDefinition = $this->createMock(Definition::class);
+        $managerDefinition->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
 
         $this->container->setDefinition('acme.block.service', $blockDefinition);
-        $this->container->setDefinition('sonata.block.manager', $managerDefintion);
+        $this->container->setDefinition('sonata.block.manager', $managerDefinition);
 
         $pass = new TweakCompilerPass();
         $pass->process($this->container);

--- a/tests/DependencyInjection/Compiler/TweakCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/TweakCompilerPassTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\DependencyInjection\Compiler\TweakCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class TweakCompilerPassTest extends TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * Setup test object.
+     */
+    public function setUp()
+    {
+        $this->container = new ContainerBuilder();
+
+        $this->container->setDefinition('sonata.block.menu.registry', $this->createMock(Definition::class));
+        $this->container->setDefinition('sonata.block.loader.chain', $this->createMock(Definition::class));
+        $this->container->setDefinition('sonata.block.context_manager', $this->createMock(Definition::class));
+
+        $this->container->setParameter('sonata_block.blocks', []);
+        $this->container->setParameter('sonata_block.blocks_by_class', []);
+    }
+
+    public function testProcessAutowired()
+    {
+        $blockDefinition = new Definition(null, ['acme.block.service']);
+        $blockDefinition->addTag('sonata.block');
+        $blockDefinition->setAutoconfigured(true);
+
+        $managerDefintion = $this->createMock(Definition::class);
+        $managerDefintion->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
+
+        $this->container->setDefinition('acme.block.service', $blockDefinition);
+        $this->container->setDefinition('sonata.block.manager', $managerDefintion);
+
+        $pass = new TweakCompilerPass();
+        $pass->process($this->container);
+    }
+
+    public function testProcessSameBlockId()
+    {
+        /** @var Definition $blockDefinition */
+        $blockDefinition = new Definition(null, ['acme.block.service']);
+        $blockDefinition->addTag('sonata.block');
+
+        $managerDefintion = $this->createMock(Definition::class);
+        $managerDefintion->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
+
+        $this->container->setDefinition('acme.block.service', $blockDefinition);
+        $this->container->setDefinition('sonata.block.manager', $managerDefintion);
+
+        $pass = new TweakCompilerPass();
+        $pass->process($this->container);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testProcessDifferentBlockId()
+    {
+        /** @var Definition $blockDefinition */
+        $blockDefinition = new Definition(null, ['acme.block.service.name']);
+        $blockDefinition->addTag('sonata.block');
+
+        $managerDefintion = $this->createMock(Definition::class);
+        $managerDefintion->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
+
+        $this->container->setDefinition('acme.block.service', $blockDefinition);
+        $this->container->setDefinition('sonata.block.manager', $managerDefintion);
+
+        $pass = new TweakCompilerPass();
+        $pass->process($this->container);
+    }
+
+    public function testProcesEmptyBlockId()
+    {
+        /** @var Definition $blockDefinition */
+        $blockDefinition = new Definition();
+        $blockDefinition->addTag('sonata.block');
+
+        $managerDefintion = $this->createMock(Definition::class);
+        $managerDefintion->expects($this->once())->method('addMethodCall')->with('add', ['acme.block.service', 'acme.block.service', []]);
+
+        $this->container->setDefinition('acme.block.service', $blockDefinition);
+        $this->container->setDefinition('sonata.block.manager', $managerDefintion);
+
+        $pass = new TweakCompilerPass();
+        $pass->process($this->container);
+
+        $this->assertEquals('acme.block.service', $blockDefinition->getArgument(0));
+    }
+}

--- a/tests/DependencyInjection/Compiler/TweakCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/TweakCompilerPassTest.php
@@ -40,6 +40,12 @@ final class TweakCompilerPassTest extends TestCase
 
     public function testProcessAutowired()
     {
+        if (!method_exists(Definition::class, 'setAutoconfigured')) {
+            $this->markTestSkipped(
+              'Autowiring does not exist in < symfony 3.'
+            );
+        }
+
         $blockDefinition = new Definition(null, ['acme.block.service']);
         $blockDefinition->addTag('sonata.block');
         $blockDefinition->setAutoconfigured(true);
@@ -92,7 +98,7 @@ final class TweakCompilerPassTest extends TestCase
     public function testProcesEmptyBlockId()
     {
         /** @var Definition $blockDefinition */
-        $blockDefinition = new Definition();
+        $blockDefinition = new Definition(null, ['']);
         $blockDefinition->addTag('sonata.block');
 
         $managerDefintion = $this->createMock(Definition::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Allow autowiring blocks
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

You couldn't use autowiring, because the Compiler Pass tries to fill in the service name every time.
