### PR TITLE
Decouple bundle from AdminBundle

### DIFF
--- a/src/Block/Service/EditableBlockService.php
+++ b/src/Block/Service/EditableBlockService.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Block\Service;
+
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\MetadataInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\Form\Validator\ErrorElement;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+interface EditableBlockService
+{
+    public function configureEditForm(FormMapper $form, BlockInterface $block);
+
+    public function configureCreateForm(FormMapper $form, BlockInterface $block);
+
+    public function validate(ErrorElement $errorElement, BlockInterface $block);
+
+    /**
+     * @param string|null $code
+     *
+     * @return MetadataInterface
+     */
+    public function getMetadata($code = null);
+}

--- a/src/Form/Mapper/FormMapper.php
+++ b/src/Form/Mapper/FormMapper.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Form\Mapper;
+
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+interface FormMapper
+{
+    /**
+     * @param string $name
+     * @param mixed  $type
+     *
+     * @return FormBuilderInterface
+     */
+    public function create($name, $type = null, array $options = []);
+
+    /**
+     * @param array $keys field names
+     *
+     * @return self
+     */
+    public function reorder(array $keys);
+
+    /**
+     * @param FormBuilderInterface|string $name
+     * @param string                      $type
+     *
+     * @return self
+     */
+    public function add($name, $type = null, array $options = []);
+
+    /**
+     * @param string $key
+     *
+     * @return self
+     */
+    public function remove($key);
+
+    /**
+     * @return self
+     */
+    public function setHelps(array $helps = []);
+
+    /**
+     * @return self
+     */
+    public function addHelp($name, $help);
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function has($key);
+
+    /**
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function get($name);
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #493

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `EditableBlockService` and `FormMapper` interfaces
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

This is the first step to decouple this bundle from the AdminBundle by inversing the dependencies. After merging this, we need to create an adapter in the AdminBundle.

Depends on https://github.com/sonata-project/form-extensions/pull/7/files