### PR TITLE
Added some information about cache keys to the documentation

### DIFF
--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -78,7 +78,7 @@ it is mandatory to overwrite the ``getCacheKeys`` function in your custom block 
 
     <?php
 
-    class CachedBlock extends AbstractBlockService implements BlockServiceInterface
+    final class CachedBlock extends AbstractBlockService
     {
         public function execute(BlockContextInterface $blockContext, Response $response = null) { /*... */ }
 

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -69,7 +69,7 @@ or you can use the `Response` object:
 Cache Keys
 ::::::::::
 
-The ``SonataCacheBundle`` needs cache keys in order to find cached
+The ``SonataCacheBundle`` needs cache keys in order to find cached blocks.
 blocks. By default cache keys consist of the ``block_id`` and the ``updated_at``
 timestamp. Because these values change on every call from the Twig Helper,
 it is mandatory to overwrite the ``getCacheKeys`` function in your custom block class:

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -69,10 +69,10 @@ or you can use the `Response` object:
 Cache Keys
 ::::::::::
 
-The ``SonataCacheBundle`` needs ``CacheKeys`` in order to find cached
-blocks. By default ``CacheKeys`` consist of the ``block_id`` and the ``updated_at``
+The ``SonataCacheBundle`` needs cache keys in order to find cached
+blocks. By default cache keys consist of the ``block_id`` and the ``updated_at``
 timestamp. Because these values change on every call from the Twig Helper,
-it is mandatory to overwrite the ``getCacheKeys`` function:
+it is mandatory to overwrite the ``getCacheKeys`` function in your custom block class:
 
 .. code-block:: php
 

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -66,6 +66,22 @@ or you can use the `Response` object:
         return Response::create(sprintf("your name is %s", $user->getUsername()))->setTtl(0)->setPrivate();
     }
 
+Cache Keys
+::::::::::
+
+The ``SonataCacheBundle`` needs ``CacheKeys`` in order to find cached blocks. By default ``CacheKeys`` consist of the ``block_id`` and the ``updated_at`` timestamp. Because these values change on every call from the Twig Helper, it is mandatory to overwrite the ``getCacheKeys`` function:
+
+.. code-block:: php
+
+    <?php
+
+    public function getCacheKeys(BlockInterface $block)
+    {
+        return [
+            'id' => 'sample_cached_block'
+        ];
+    }
+
 Block TTL computation
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -80,7 +80,10 @@ it is mandatory to overwrite the ``getCacheKeys`` function in your custom block 
 
     final class CachedBlock extends AbstractBlockService
     {
-        public function execute(BlockContextInterface $blockContext, Response $response = null) { /*... */ }
+        public function execute(BlockContextInterface $blockContext, Response $response = null)
+        {
+            // ...
+        }
 
         public function getCacheKeys(BlockInterface $block)
         {

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -84,7 +84,7 @@ it is mandatory to overwrite the ``getCacheKeys`` function in your custom block 
 
     final class CachedBlock extends AbstractBlockService
     {
-        public function execute(BlockContextInterface $blockContext, Response $response = null)
+        public function execute(BlockContextInterface $blockContext, Response $response = null): Response
         {
             // ...
         }

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -89,7 +89,7 @@ it is mandatory to overwrite the ``getCacheKeys`` function in your custom block 
             // ...
         }
 
-        public function getCacheKeys(BlockInterface $block)
+        public function getCacheKeys(BlockInterface $block): array
         {
             return [
                 'id' => 'sample_cached_block'

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -69,7 +69,10 @@ or you can use the `Response` object:
 Cache Keys
 ::::::::::
 
-The ``SonataCacheBundle`` needs ``CacheKeys`` in order to find cached blocks. By default ``CacheKeys`` consist of the ``block_id`` and the ``updated_at`` timestamp. Because these values change on every call from the Twig Helper, it is mandatory to overwrite the ``getCacheKeys`` function:
+The ``SonataCacheBundle`` needs ``CacheKeys`` in order to find cached
+blocks. By default ``CacheKeys`` consist of the ``block_id`` and the ``updated_at``
+timestamp. Because these values change on every call from the Twig Helper,
+it is mandatory to overwrite the ``getCacheKeys`` function:
 
 .. code-block:: php
 

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -78,11 +78,17 @@ it is mandatory to overwrite the ``getCacheKeys`` function:
 
     <?php
 
-    public function getCacheKeys(BlockInterface $block)
+    class CachedBlock extends AbstractBlockService implements BlockServiceInterface
     {
-        return [
-            'id' => 'sample_cached_block'
-        ];
+        public function execute(BlockContextInterface $blockContext, Response $response = null) { /*... */ }
+
+        public function getCacheKeys(BlockInterface $block)
+        {
+            return [
+                'id' => 'sample_cached_block'
+            ];
+        }
+        // ...
     }
 
 Block TTL computation

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -78,6 +78,9 @@ it is mandatory to overwrite the ``getCacheKeys`` function in your custom block 
 
     <?php
 
+    namespace App\Block;
+    
+    use Sonata\BlockBundle\Block\Service\AbstractBlockService;
     final class CachedBlock extends AbstractBlockService
     {
         public function execute(BlockContextInterface $blockContext, Response $response = null)

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -81,6 +81,7 @@ it is mandatory to overwrite the ``getCacheKeys`` function in your custom block 
     namespace App\Block;
     
     use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+
     final class CachedBlock extends AbstractBlockService
     {
         public function execute(BlockContextInterface $blockContext, Response $response = null)

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -70,7 +70,7 @@ Cache Keys
 ::::::::::
 
 The ``SonataCacheBundle`` needs cache keys in order to find cached blocks.
-blocks. By default cache keys consist of the ``block_id`` and the ``updated_at``
+By default cache keys consist of the ``block_id`` and the ``updated_at``
 timestamp. Because these values change on every call from the Twig Helper,
 it is mandatory to overwrite the ``getCacheKeys`` function in your custom block class:
 

--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -81,6 +81,9 @@ it is mandatory to overwrite the ``getCacheKeys`` function in your custom block 
     namespace App\Block;
     
     use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+    use Sonata\BlockBundle\Block\BlockContextInterface;
+    use Sonata\BlockBundle\Model\BlockInterface;
+    use Symfony\Component\HttpFoundation\Response;
 
     final class CachedBlock extends AbstractBlockService
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these are just some documentation additions.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject
The documentation does not seem to address changing block ids and thus cache misses. I added some information based on my knowledge to the documentation.

<!-- Describe your Pull Request content here -->
