### PR TITLE
Corrige a typo in a parameter name.

### DIFF
--- a/src/DependencyInjection/SonataBlockExtension.php
+++ b/src/DependencyInjection/SonataBlockExtension.php
@@ -174,7 +174,7 @@ class SonataBlockExtension extends Extension
             $types[] = $service;
         }
 
-        $container->setParameter('sonata.block.block_types', $types);
+        $container->setParameter('sonata_blocks.block_types', $types);
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because [the last commit](https://github.com/sonata-project/SonataBlockBundle/commit/555e119675604efc454e5eb8fba115d33f4ac221#diff-cf5595281888e87b6d494c89929b9757R177) add an issue with a bad parameter name.

## CHANGELOG
```markdown
### Fixed
- bad parameter name
```