### PR TITLE
Change the ChoiceType Filter

### DIFF
--- a/src/Form/Type/ContainerTemplateType.php
+++ b/src/Form/Type/ContainerTemplateType.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\BlockBundle\Form\Type;
 
-use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 

--- a/src/Form/Type/ContainerTemplateType.php
+++ b/src/Form/Type/ContainerTemplateType.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\BlockBundle\Form\Type;
 
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**


### PR DESCRIPTION
Causing an error when trying to modify an auto generated container block

I am targeting this branch, because this is the one i'm using in my project and i'm seeing a 500 error when trying to edit an auto generated block container

Closes #496

## Changelog

```markdown

### Changed
Changed which class is being used for 'ChoiceType' as a 500 error is being thrown when trying to 'Edit' an automatically created container block
```

## Subject

Just changing which class is being used for ChoiceType, this may not be the best method, but it is one that fixes the problem at first glance.
