### PR TITLE
Improve performance and entropy thanks to $more_entropy in uniqid()

### DIFF
--- a/docs/reference/events.rst
+++ b/docs/reference/events.rst
@@ -55,7 +55,7 @@ The `event listener` must push one or some ``BlockInterface`` instances into ``B
         public function onBlock(BlockEvent $event)
         {
             $block = new Block();
-            $block->setId(uniqid()); // set a fake id
+            $block->setId(uniqid('', true)); // set a fake id
             $block->setSettings($event->getSettings());
             $block->setType('sonata.comment.block.discus');
 

--- a/src/Block/Loader/ServiceLoader.php
+++ b/src/Block/Loader/ServiceLoader.php
@@ -56,7 +56,7 @@ class ServiceLoader implements BlockLoaderInterface
         }
 
         $block = new Block();
-        $block->setId(uniqid());
+        $block->setId(uniqid('', true));
         $block->setType($configuration['type']);
         $block->setEnabled(true);
         $block->setCreatedAt(new \DateTime());

--- a/src/Event/TextBlockListener.php
+++ b/src/Event/TextBlockListener.php
@@ -43,7 +43,7 @@ class TextBlockListener
         }
 
         $block = new Block();
-        $block->setId(uniqid());
+        $block->setId(uniqid('', true));
         $block->setSettings([
             'content' => $event->getSetting('content', $content),
         ]);

--- a/src/Templating/Helper/BlockHelper.php
+++ b/src/Templating/Helper/BlockHelper.php
@@ -184,7 +184,7 @@ class BlockHelper extends Helper
         }
 
         if ($this->stopwatch) {
-            $this->traces['_events'][uniqid()] = [
+            $this->traces['_events'][uniqid('', true)] = [
                 'template_code' => $name,
                 'event_name' => $eventName,
                 'blocks' => $this->getEventBlocks($event),


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Use `$more_entropy = true` when calling `uniqid()`: faster and better

I was running a project which uses this bundle. I found that it uses `uniqid()` a few times. By changing the second parameter to `true` the entropy is safer and the execution is faster.

So, I did it everywhere I found `uniqid()`. It doesn't change the result of the method, it's just faster and the entropy is better. So, why not?

It's a simple patch, should be on `3.x`.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Improve performance and entropy when calling `uniqid` from [@jacquesbh](https://github.com/jacquesbh).
```