### PR TITLE
Stop extending deprecated class `ContainerAwareCommand`

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -14,15 +14,46 @@ declare(strict_types=1);
 namespace Sonata\BlockBundle\Command;
 
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 
-abstract class BaseCommand extends ContainerAwareCommand
+abstract class BaseCommand extends Command
 {
+    /**
+     * @var BlockServiceManagerInterface
+     */
+    protected $blockManager;
+
+    public function __construct(string $name = null, BlockServiceManagerInterface $blockManager = null)
+    {
+        // NEXT_MAJOR: Remove the default value for argument 2 and the following condition
+        if (null === $blockManager) {
+            throw new \InvalidArgumentException(sprintf(
+                'Argument 2 passed to %s::%s() must be an instance of %s, %s given.',
+                static::class,
+                __FUNCTION__,
+                BlockServiceManagerInterface::class,
+                \gettype($blockManager)
+            ));
+        }
+
+        $this->blockManager = $blockManager;
+
+        parent::__construct($name);
+    }
+
     /**
      * @return BlockServiceManagerInterface
      */
     public function getBlockServiceManager()
     {
-        return $this->getContainer()->get('sonata.block.manager');
+        // NEXT_MAJOR: Remove this method
+        @trigger_error(sprintf(
+            'Method %1$s::%2$s() is deprecated since sonata-project/block-bundle 3.x and will be removed with the 4.0 release.'.
+            'Use the %1$s::$blockManager property instead.',
+            static::class,
+            __FUNCTION__
+        ), E_USER_DEPRECATED);
+
+        return $this->blockManager;
     }
 }

--- a/src/Command/DebugBlocksCommand.php
+++ b/src/Command/DebugBlocksCommand.php
@@ -18,16 +18,28 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DebugBlocksCommand extends BaseCommand
+/**
+ * @final since sonata-project/block-bundle 4.0
+ *
+ * NEXT_MAJOR: Uncomment the "final" class declaration
+ */
+/* final */class DebugBlocksCommand extends BaseCommand
 {
+    /**
+     * {@inheritdoc}
+     *
+     * NEXT_MAJOR: Rename to "debug:sonata:block"
+     */
+    protected static $defaultName = 'sonata:block:debug';
+
     /**
      * {@inheritdoc}
      */
     public function configure()
     {
-        // NEXT_MAJOR: Switch name and alias
+        $this->setName(static::$defaultName); // BC for symfony/console < 3.4.0
+        // NEXT_MAJOR: Replace the current alias by "sonata:block:debug"
         $this->setAliases(['debug:sonata:block']);
-        $this->setName('sonata:block:debug');
         $this->setDescription('Debug all blocks available, show default settings of each block');
 
         $this->addOption('context', 'c', InputOption::VALUE_REQUIRED, 'display service for the specified context');
@@ -38,10 +50,18 @@ class DebugBlocksCommand extends BaseCommand
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        if ('sonata:block:debug' === $input->getArgument('command')) {
+            // NEXT_MAJOR: Remove this check
+            @trigger_error(
+                'Command "sonata:block:debug" is deprecated since sonata-project/block-bundle 3.x and will be removed with the 4.0 release.'.
+                ' Use the "debug:sonata:block" command instead.',
+                E_USER_DEPRECATED
+            );
+        }
         if ($input->getOption('context')) {
-            $services = $this->getBlockServiceManager()->getServicesByContext($input->getOption('context'));
+            $services = $this->blockManager->getServicesByContext($input->getOption('context'));
         } else {
-            $services = $this->getBlockServiceManager()->getServices();
+            $services = $this->blockManager->getServices();
         }
 
         foreach ($services as $code => $service) {

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -2,6 +2,8 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Sonata\BlockBundle\Command\DebugBlocksCommand" class="Sonata\BlockBundle\Command\DebugBlocksCommand">
+            <argument/>
+            <argument type="service" id="sonata.block.manager"/>
             <tag name="console.command"/>
         </service>
     </services>

--- a/tests/Command/DebugBlocksCommandTest.php
+++ b/tests/Command/DebugBlocksCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
+use Sonata\BlockBundle\Command\DebugBlocksCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class DebugBlocksCommandTest extends TestCase
+{
+    /**
+     * @var Application
+     */
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+
+        $blockManager = $this->createMock(BlockServiceManagerInterface::class);
+        $blockManager
+            ->expects($this->any())
+            ->method('getServices')
+            ->willReturn([]);
+
+        $this->application->add(new DebugBlocksCommand(null, $blockManager));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->application = null;
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Command "sonata:block:debug" is deprecated since sonata-project/block-bundle 3.x and will be removed with the 4.0 release. Use the "debug:sonata:block" command instead.
+     */
+    public function testExecute(): void
+    {
+        $command = $this->application->find('sonata:block:debug');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => 'sonata:block:debug']);
+
+        $this->assertSame("done!\n", $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithAlias(): void
+    {
+        $command = $this->application->find('debug:sonata:block');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => 'debug:sonata:block']);
+
+        $this->assertSame("done!\n", $commandTester->getDisplay());
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Method Sonata\BlockBundle\Command\DebugBlocksCommand::getBlockServiceManager() is deprecated since sonata-project/block-bundle 3.x and will be removed with the 4.0 release.Use the Sonata\BlockBundle\Command\DebugBlocksCommand::$blockManager property instead.
+     */
+    public function testGetBlockServiceManager(): void
+    {
+        $blockManager = $this->createMock(BlockServiceManagerInterface::class);
+        $blockManager
+            ->expects($this->any())
+            ->method('getServices')
+            ->willReturn([]);
+
+        (new DebugBlocksCommand(null, $blockManager))->getBlockServiceManager();
+    }
+
+    public function testConstructorArguments(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument 2 passed to Sonata\BlockBundle\Command\DebugBlocksCommand::__construct() must be an instance of Sonata\BlockBundle\Block\BlockServiceManagerInterface, NULL given.');
+
+        new DebugBlocksCommand();
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Stop extending deprecated class `ContainerAwareCommand`.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes tries to respect BC as much as possible.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `BaseCommand::getBlockServiceManager()` method in favor of `BaseCommand::$blockManager` property;
- Extending `DebugBlocksCommand` class, which will be declared final in 4.0;
- Invoking `DebugBlocksCommand` with "debug:sonata:block" as name.

### Fixed
- Deprecation caused by usage of `ContainerAwareCommand`.
```
    
## To do
    
- [x] Add tests;
- [x] Validate with core members why the command defined by `DebugBlocksCommand` requires an alias, and check if we must instead deprecate invocations with some of these names.
