### PR TITLE
Catch MissingOptionsException in DebugBlocksCommand

### DIFF
--- a/src/Command/DebugBlocksCommand.php
+++ b/src/Command/DebugBlocksCommand.php
@@ -16,6 +16,7 @@ namespace Sonata\BlockBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -65,6 +66,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
         }
 
         foreach ($services as $code => $service) {
+            $output->writeln('');
+            $output->writeln(sprintf('<info>>> %s</info> (<comment>%s</comment>)', $service->getName(), $code));
+
             $resolver = new OptionsResolver();
 
             // NEXT_MAJOR: Remove this check
@@ -74,13 +78,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
                 $service->setDefaultSettings($resolver);
             }
 
-            $settings = $resolver->resolve();
-
-            $output->writeln('');
-            $output->writeln(sprintf('<info>>> %s</info> (<comment>%s</comment>)', $service->getName(), $code));
-
-            foreach ($settings as $key => $val) {
-                $output->writeln(sprintf('    %-30s%s', $key, json_encode($val)));
+            try {
+                foreach ($resolver->resolve() as $key => $val) {
+                    $output->writeln(sprintf('    %-30s%s', $key, json_encode($val)));
+                }
+            } catch (MissingOptionsException $e) {
+                foreach ($resolver->getDefinedOptions() as $option) {
+                    $output->writeln(sprintf('    %s', $option));
+                }
             }
         }
 

--- a/tests/Command/DebugBlocksCommandTest.php
+++ b/tests/Command/DebugBlocksCommandTest.php
@@ -105,13 +105,13 @@ class DebugBlocksCommandTest extends TestCase
             ->expects($this->any())
             ->method('getServices')
             ->willReturn([
-                'test.without_options' => new class extends AbstractBlockService {
+                'test.without_options' => new class() extends AbstractBlockService {
                     public function getName()
                     {
                         return 'Test service block without options';
                     }
                 },
-                'test.with_simple_option' => new class extends AbstractBlockService {
+                'test.with_simple_option' => new class() extends AbstractBlockService {
                     public function configureSettings(OptionsResolver $resolver)
                     {
                         $resolver->setDefault('limit', 150);
@@ -123,7 +123,7 @@ class DebugBlocksCommandTest extends TestCase
                         return 'Test service block with simple option';
                     }
                 },
-                'test.with_required_option' => new class extends AbstractBlockService {
+                'test.with_required_option' => new class() extends AbstractBlockService {
                     public function configureSettings(OptionsResolver $resolver)
                     {
                         $resolver->setRequired('limit');

--- a/tests/Command/DebugBlocksCommandTest.php
+++ b/tests/Command/DebugBlocksCommandTest.php
@@ -15,9 +15,11 @@ namespace Sonata\BlockBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Command\DebugBlocksCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>
@@ -92,5 +94,68 @@ class DebugBlocksCommandTest extends TestCase
         $this->expectExceptionMessage('Argument 2 passed to Sonata\BlockBundle\Command\DebugBlocksCommand::__construct() must be an instance of Sonata\BlockBundle\Block\BlockServiceManagerInterface, NULL given.');
 
         new DebugBlocksCommand();
+    }
+
+    public function testDebugBlocks(): void
+    {
+        $this->application = new Application();
+
+        $blockManager = $this->createMock(BlockServiceManagerInterface::class);
+        $blockManager
+            ->expects($this->any())
+            ->method('getServices')
+            ->willReturn([
+                'test.without_options' => new class extends AbstractBlockService {
+                    public function getName()
+                    {
+                        return 'Test service block without options';
+                    }
+                },
+                'test.with_simple_option' => new class extends AbstractBlockService {
+                    public function configureSettings(OptionsResolver $resolver)
+                    {
+                        $resolver->setDefault('limit', 150);
+                        $resolver->setAllowedTypes('limit', 'int');
+                    }
+
+                    public function getName()
+                    {
+                        return 'Test service block with simple option';
+                    }
+                },
+                'test.with_required_option' => new class extends AbstractBlockService {
+                    public function configureSettings(OptionsResolver $resolver)
+                    {
+                        $resolver->setRequired('limit');
+                        $resolver->setAllowedTypes('limit', 'int');
+                    }
+
+                    public function getName()
+                    {
+                        return 'Test service block with required option';
+                    }
+                },
+            ]);
+
+        $this->application->add(new DebugBlocksCommand(null, $blockManager));
+
+        $command = $this->application->find('debug:sonata:block');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => 'debug:sonata:block']);
+
+        $expected = <<<EOF
+
+>> Test service block without options (test.without_options)
+
+>> Test service block with simple option (test.with_simple_option)
+    limit                         150
+
+>> Test service block with required option (test.with_required_option)
+    limit
+done!
+
+EOF;
+
+        $this->assertSame($expected, $commandTester->getDisplay());
     }
 }

--- a/tests/Command/DebugBlocksCommandTest.php
+++ b/tests/Command/DebugBlocksCommandTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Command\DebugBlocksCommand;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -99,40 +100,27 @@ class DebugBlocksCommandTest extends TestCase
     public function testDebugBlocks(): void
     {
         $this->application = new Application();
+        $templating = $this->createMock(EngineInterface::class);
 
         $blockManager = $this->createMock(BlockServiceManagerInterface::class);
         $blockManager
             ->expects($this->any())
             ->method('getServices')
             ->willReturn([
-                'test.without_options' => new class() extends AbstractBlockService {
-                    public function getName()
-                    {
-                        return 'Test service block without options';
-                    }
+                'test.without_options' => new class('Test service block without options', $templating) extends AbstractBlockService {
                 },
-                'test.with_simple_option' => new class() extends AbstractBlockService {
+                'test.with_simple_option' => new class('Test service block with simple option', $templating) extends AbstractBlockService {
                     public function configureSettings(OptionsResolver $resolver)
                     {
                         $resolver->setDefault('limit', 150);
                         $resolver->setAllowedTypes('limit', 'int');
                     }
-
-                    public function getName()
-                    {
-                        return 'Test service block with simple option';
-                    }
                 },
-                'test.with_required_option' => new class() extends AbstractBlockService {
+                'test.with_required_option' => new class('Test service block with required option', $templating) extends AbstractBlockService {
                     public function configureSettings(OptionsResolver $resolver)
                     {
                         $resolver->setRequired('limit');
                         $resolver->setAllowedTypes('limit', 'int');
-                    }
-
-                    public function getName()
-                    {
-                        return 'Test service block with required option';
                     }
                 },
             ]);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

If we have blocks that have required options without a default value, then invoking the command `sonata:block:debug` will result in an error.

```php
class EventWithDiscountsBlock extends AbstractBlockService
{
    public function configureSettings(OptionsResolver $resolver): void
    {
        $resolver->setRequired('city');
        $resolver->setAllowedTypes('city', 'string');
        $resolver->setAllowedValues('city', function ($value) {
            return City::isValid($value);
        });
        $resolver->setRequired('limit');
        $resolver->setAllowedTypes('limit', 'int');
        $resolver->setDefault('template', '@Frontend/block/events_with_discounts.html.twig');
    }

    // ..
}
```

```
# ./bin/console sonata:block:debug
15:37:36 ERROR     [console] Error thrown while running command "sonata:block:debug --env prod". Message: "The required options "city", "limit" are missing."
[
  "exception" => Symfony\Component\OptionsResolver\Exception\MissingOptionsException {
    #message: "The required options "city", "limit" are missing."
    #code: 0
    #file: "./vendor/symfony/symfony/src/Symfony/Component/OptionsResolver/OptionsResolver.php"
    #line: 660
    trace: {
      ./vendor/symfony/symfony/src/Symfony/Component/OptionsResolver/OptionsResolver.php:660 { …}
      ./vendor/sonata-project/block-bundle/src/Command/DebugBlocksCommand.php:57 { …}
      ./vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:255 { …}
      ./vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:987 { …}
      ./vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:86 { …}
      ./vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:255 { …}
      ./vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:74 { …}
      ./vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:148 { …}
      ./bin/console:50 {
        ›
        › $application->run($input);
        ›
        arguments: {
          $input: Symfony\Component\Console\Input\ArgvInput {#1 …}
        }
      }
    }
  },
  "command" => "sonata:block:debug --env prod",
  "message" => "The required options "city", "limit" are missing."
]

In OptionsResolver.php line 660:

  [Symfony\Component\OptionsResolver\Exception\MissingOptionsException]
  The required options "city", "limit" are missing.


Exception trace:
 () at /application/vendor/symfony/symfony/src/Symfony/Component/OptionsResolver/OptionsResolver.php:660
 Symfony\Component\OptionsResolver\OptionsResolver->resolve() at /application/vendor/sonata-project/block-bundle/src/Command/DebugBlocksCommand.php:57
 Sonata\BlockBundle\Command\DebugBlocksCommand->execute() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:987
 Symfony\Component\Console\Application->doRunCommand() at /application/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:86
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:255
 Symfony\Component\Console\Application->doRun() at /application/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:74
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:148
 Symfony\Component\Console\Application->run() at /application/bin/console:50

sonata:block:debug [-c|--context CONTEXT] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--n
o-progress] [--] <command>
```

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed error when debugging blocks with the required options.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
