### PR TITLE
Allow Travis CI to build on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
   - '7.1'
   - '7.2'
   - '7.3'
-  - '7.4snapshot'
+  - '7.4'
   - nightly
 
 dist: xenial
@@ -56,7 +56,7 @@ matrix:
     - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0
   allow_failures:
-    - php: 7.4snapshot
+    - php: 7.4
     - php: nightly
     - env: SYMFONY_DEPRECATIONS_HELPER=0
     - env: SYMFONY='dev-master as 3.4.x-dev'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ php:
   - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4snapshot'
   - nightly
 
 dist: xenial
@@ -55,6 +56,7 @@ matrix:
     - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0
   allow_failures:
+    - php: 7.4snapshot
     - php: nightly
     - env: SYMFONY_DEPRECATIONS_HELPER=0
     - env: SYMFONY='dev-master as 3.4.x-dev'


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Allow Travis CI to build on PHP 7.4.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change doesn't affect BC.