### PR TITLE
Remove implicit depencency against "sonata-project/admin-bundle"

### DIFF
--- a/src/Block/Service/AbstractAdminBlockService.php
+++ b/src/Block/Service/AbstractAdminBlockService.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Block\Service;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;

--- a/src/Block/Service/AdminBlockServiceInterface.php
+++ b/src/Block/Service/AdminBlockServiceInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Block\Service;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;

--- a/src/Block/Service/ContainerBlockService.php
+++ b/src/Block/Service/ContainerBlockService.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Block\Service;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Form\Type\ContainerTemplateType;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;

--- a/src/Block/Service/EditableBlockService.php
+++ b/src/Block/Service/EditableBlockService.php
@@ -29,10 +29,5 @@ interface EditableBlockService
 
     public function validate(ErrorElement $errorElement, BlockInterface $block);
 
-    /**
-     * @param string|null $code
-     *
-     * @return MetadataInterface
-     */
-    public function getMetadata($code = null);
+    public function getMetadata(): MetadataInterface;
 }

--- a/src/Block/Service/EmptyBlockService.php
+++ b/src/Block/Service/EmptyBlockService.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Block\Service;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Block/Service/MenuBlockService.php
+++ b/src/Block/Service/MenuBlockService.php
@@ -15,8 +15,8 @@ namespace Sonata\BlockBundle\Block\Service;
 
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Menu\MenuRegistry;
 use Sonata\BlockBundle\Menu\MenuRegistryInterface;
 use Sonata\BlockBundle\Meta\Metadata;

--- a/src/Block/Service/RssBlockService.php
+++ b/src/Block/Service/RssBlockService.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Block\Service;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;

--- a/src/Block/Service/TemplateBlockService.php
+++ b/src/Block/Service/TemplateBlockService.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Block\Service;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Type\ImmutableArrayType;

--- a/src/Block/Service/TextBlockService.php
+++ b/src/Block/Service/TextBlockService.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Block\Service;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Type\ImmutableArrayType;

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -14,15 +14,46 @@ declare(strict_types=1);
 namespace Sonata\BlockBundle\Command;
 
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 
-abstract class BaseCommand extends ContainerAwareCommand
+abstract class BaseCommand extends Command
 {
+    /**
+     * @var BlockServiceManagerInterface
+     */
+    protected $blockManager;
+
+    public function __construct(string $name = null, BlockServiceManagerInterface $blockManager = null)
+    {
+        // NEXT_MAJOR: Remove the default value for argument 2 and the following condition
+        if (null === $blockManager) {
+            throw new \InvalidArgumentException(sprintf(
+                'Argument 2 passed to %s::%s() must be an instance of %s, %s given.',
+                static::class,
+                __FUNCTION__,
+                BlockServiceManagerInterface::class,
+                \gettype($blockManager)
+            ));
+        }
+
+        $this->blockManager = $blockManager;
+
+        parent::__construct($name);
+    }
+
     /**
      * @return BlockServiceManagerInterface
      */
     public function getBlockServiceManager()
     {
-        return $this->getContainer()->get('sonata.block.manager');
+        // NEXT_MAJOR: Remove this method
+        @trigger_error(sprintf(
+            'Method %1$s::%2$s() is deprecated since sonata-project/block-bundle 3.x and will be removed with the 4.0 release.'.
+            'Use the %1$s::$blockManager property instead.',
+            static::class,
+            __FUNCTION__
+        ), E_USER_DEPRECATED);
+
+        return $this->blockManager;
     }
 }

--- a/src/Command/DebugBlocksCommand.php
+++ b/src/Command/DebugBlocksCommand.php
@@ -16,6 +16,7 @@ namespace Sonata\BlockBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -65,6 +66,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
         }
 
         foreach ($services as $code => $service) {
+            $output->writeln('');
+            $output->writeln(sprintf('<info>>> %s</info> (<comment>%s</comment>)', $service->getName(), $code));
+
             $resolver = new OptionsResolver();
 
             // NEXT_MAJOR: Remove this check
@@ -74,13 +78,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
                 $service->setDefaultSettings($resolver);
             }
 
-            $settings = $resolver->resolve();
-
-            $output->writeln('');
-            $output->writeln(sprintf('<info>>> %s</info> (<comment>%s</comment>)', $service->getName(), $code));
-
-            foreach ($settings as $key => $val) {
-                $output->writeln(sprintf('    %-30s%s', $key, json_encode($val)));
+            try {
+                foreach ($resolver->resolve() as $key => $val) {
+                    $output->writeln(sprintf('    %-30s%s', $key, json_encode($val)));
+                }
+            } catch (MissingOptionsException $e) {
+                foreach ($resolver->getDefinedOptions() as $option) {
+                    $output->writeln(sprintf('    %s', $option));
+                }
             }
         }
 

--- a/src/Command/DebugBlocksCommand.php
+++ b/src/Command/DebugBlocksCommand.php
@@ -18,16 +18,28 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class DebugBlocksCommand extends BaseCommand
+/**
+ * @final since sonata-project/block-bundle 4.0
+ *
+ * NEXT_MAJOR: Uncomment the "final" class declaration
+ */
+/* final */class DebugBlocksCommand extends BaseCommand
 {
+    /**
+     * {@inheritdoc}
+     *
+     * NEXT_MAJOR: Rename to "debug:sonata:block"
+     */
+    protected static $defaultName = 'sonata:block:debug';
+
     /**
      * {@inheritdoc}
      */
     public function configure()
     {
-        // NEXT_MAJOR: Switch name and alias
+        $this->setName(static::$defaultName); // BC for symfony/console < 3.4.0
+        // NEXT_MAJOR: Replace the current alias by "sonata:block:debug"
         $this->setAliases(['debug:sonata:block']);
-        $this->setName('sonata:block:debug');
         $this->setDescription('Debug all blocks available, show default settings of each block');
 
         $this->addOption('context', 'c', InputOption::VALUE_REQUIRED, 'display service for the specified context');
@@ -38,10 +50,18 @@ class DebugBlocksCommand extends BaseCommand
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        if ('sonata:block:debug' === $input->getArgument('command')) {
+            // NEXT_MAJOR: Remove this check
+            @trigger_error(
+                'Command "sonata:block:debug" is deprecated since sonata-project/block-bundle 3.x and will be removed with the 4.0 release.'.
+                ' Use the "debug:sonata:block" command instead.',
+                E_USER_DEPRECATED
+            );
+        }
         if ($input->getOption('context')) {
-            $services = $this->getBlockServiceManager()->getServicesByContext($input->getOption('context'));
+            $services = $this->blockManager->getServicesByContext($input->getOption('context'));
         } else {
-            $services = $this->getBlockServiceManager()->getServices();
+            $services = $this->blockManager->getServices();
         }
 
         foreach ($services as $code => $service) {

--- a/src/Form/Mapper/FormMapper.php
+++ b/src/Form/Mapper/FormMapper.php
@@ -21,56 +21,30 @@ use Symfony\Component\Form\FormBuilderInterface;
 interface FormMapper
 {
     /**
-     * @param string $name
-     * @param mixed  $type
-     *
-     * @return FormBuilderInterface
+     * @param mixed $type
      */
-    public function create($name, $type = null, array $options = []);
+    public function create(string $name, ?string $type = null, array $options = []): FormBuilderInterface;
 
     /**
-     * @param array $keys field names
-     *
-     * @return self
+     * @param string[] $keys field names
      */
-    public function reorder(array $keys);
+    public function reorder(array $keys): self;
 
     /**
      * @param FormBuilderInterface|string $name
-     * @param string                      $type
-     *
-     * @return self
      */
-    public function add($name, $type = null, array $options = []);
+    public function add($name, ?string $type = null, array $options = []): self;
+
+    public function remove(string $key): self;
+
+    public function setHelps(array $helps = []): self;
+
+    public function addHelp(string $name, string $help): self;
+
+    public function has(string $key): bool;
 
     /**
-     * @param string $key
-     *
-     * @return self
-     */
-    public function remove($key);
-
-    /**
-     * @return self
-     */
-    public function setHelps(array $helps = []);
-
-    /**
-     * @return self
-     */
-    public function addHelp($name, $help);
-
-    /**
-     * @param string $key
-     *
-     * @return bool
-     */
-    public function has($key);
-
-    /**
-     * @param string $key
-     *
      * @return mixed
      */
-    public function get($name);
+    public function get(string $name);
 }

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -2,7 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Sonata\BlockBundle\Command\DebugBlocksCommand" class="Sonata\BlockBundle\Command\DebugBlocksCommand">
-            <argument/>
+            <argument>null</argument>
             <argument type="service" id="sonata.block.manager"/>
             <tag name="console.command"/>
         </service>

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -2,6 +2,8 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="Sonata\BlockBundle\Command\DebugBlocksCommand" class="Sonata\BlockBundle\Command\DebugBlocksCommand">
+            <argument/>
+            <argument type="service" id="sonata.block.manager"/>
             <tag name="console.command"/>
         </service>
     </services>

--- a/tests/Block/Service/MenuBlockServiceTest.php
+++ b/tests/Block/Service/MenuBlockServiceTest.php
@@ -15,6 +15,7 @@ namespace Sonata\BlockBundle\Tests\Block\Service;
 
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\Service\MenuBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Menu\MenuRegistryInterface;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\Form\Type\ImmutableArrayType;
@@ -50,7 +51,7 @@ class MenuBlockServiceTest extends AbstractBlockServiceTestCase
                 'acme:demobundle:menu' => 'Test Menu',
             ]);
 
-        $formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')->disableOriginalConstructor()->getMock();
+        $formMapper = $this->createMock(FormMapper::class);
         $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
 
         $choiceOptions = [

--- a/tests/Command/DebugBlocksCommandTest.php
+++ b/tests/Command/DebugBlocksCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
+use Sonata\BlockBundle\Command\DebugBlocksCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class DebugBlocksCommandTest extends TestCase
+{
+    /**
+     * @var Application
+     */
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->application = new Application();
+
+        $blockManager = $this->createMock(BlockServiceManagerInterface::class);
+        $blockManager
+            ->expects($this->any())
+            ->method('getServices')
+            ->willReturn([]);
+
+        $this->application->add(new DebugBlocksCommand(null, $blockManager));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->application = null;
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Command "sonata:block:debug" is deprecated since sonata-project/block-bundle 3.x and will be removed with the 4.0 release. Use the "debug:sonata:block" command instead.
+     */
+    public function testExecute(): void
+    {
+        $command = $this->application->find('sonata:block:debug');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => 'sonata:block:debug']);
+
+        $this->assertSame("done!\n", $commandTester->getDisplay());
+    }
+
+    public function testExecuteWithAlias(): void
+    {
+        $command = $this->application->find('debug:sonata:block');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => 'debug:sonata:block']);
+
+        $this->assertSame("done!\n", $commandTester->getDisplay());
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Method Sonata\BlockBundle\Command\DebugBlocksCommand::getBlockServiceManager() is deprecated since sonata-project/block-bundle 3.x and will be removed with the 4.0 release.Use the Sonata\BlockBundle\Command\DebugBlocksCommand::$blockManager property instead.
+     */
+    public function testGetBlockServiceManager(): void
+    {
+        $blockManager = $this->createMock(BlockServiceManagerInterface::class);
+        $blockManager
+            ->expects($this->any())
+            ->method('getServices')
+            ->willReturn([]);
+
+        (new DebugBlocksCommand(null, $blockManager))->getBlockServiceManager();
+    }
+
+    public function testConstructorArguments(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument 2 passed to Sonata\BlockBundle\Command\DebugBlocksCommand::__construct() must be an instance of Sonata\BlockBundle\Block\BlockServiceManagerInterface, NULL given.');
+
+        new DebugBlocksCommand();
+    }
+}

--- a/tests/Command/DebugBlocksCommandTest.php
+++ b/tests/Command/DebugBlocksCommandTest.php
@@ -15,9 +15,12 @@ namespace Sonata\BlockBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Command\DebugBlocksCommand;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>
@@ -92,5 +95,55 @@ class DebugBlocksCommandTest extends TestCase
         $this->expectExceptionMessage('Argument 2 passed to Sonata\BlockBundle\Command\DebugBlocksCommand::__construct() must be an instance of Sonata\BlockBundle\Block\BlockServiceManagerInterface, NULL given.');
 
         new DebugBlocksCommand();
+    }
+
+    public function testDebugBlocks(): void
+    {
+        $this->application = new Application();
+        $templating = $this->createMock(EngineInterface::class);
+
+        $blockManager = $this->createMock(BlockServiceManagerInterface::class);
+        $blockManager
+            ->expects($this->any())
+            ->method('getServices')
+            ->willReturn([
+                'test.without_options' => new class('Test service block without options', $templating) extends AbstractBlockService {
+                },
+                'test.with_simple_option' => new class('Test service block with simple option', $templating) extends AbstractBlockService {
+                    public function configureSettings(OptionsResolver $resolver)
+                    {
+                        $resolver->setDefault('limit', 150);
+                        $resolver->setAllowedTypes('limit', 'int');
+                    }
+                },
+                'test.with_required_option' => new class('Test service block with required option', $templating) extends AbstractBlockService {
+                    public function configureSettings(OptionsResolver $resolver)
+                    {
+                        $resolver->setRequired('limit');
+                        $resolver->setAllowedTypes('limit', 'int');
+                    }
+                },
+            ]);
+
+        $this->application->add(new DebugBlocksCommand(null, $blockManager));
+
+        $command = $this->application->find('debug:sonata:block');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => 'debug:sonata:block']);
+
+        $expected = <<<EOF
+
+>> Test service block without options (test.without_options)
+
+>> Test service block with simple option (test.with_simple_option)
+    limit                         150
+
+>> Test service block with required option (test.with_required_option)
+    limit
+done!
+
+EOF;
+
+        $this->assertSame($expected, $commandTester->getDisplay());
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Remove implicit dependency against "sonata-project/admin-bundle".
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Triggered by #585.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Replaced declarations of `Sonata\AdminBundle\Form\FormMapper` with `Sonata\BlockBundle\Form\Mapper\FormMapper`.
```

## To do
    
- [ ] Wait for the release of sonata-project/SonataAdminBundle#5623 in order to ensure `Sonata\AdminBundle\Form\FormMapper` is implementing `Sonata\BlockBundle\Form\Mapper\FormMapper`;
- [ ] Find a replacement or another way to avoid the usage of `Sonata\AdminBundle\Admin\AdminInterface`.
