### PR TITLE
Deprecated AbstractBlockServiceTestCase class with BlockServiceTestCase

### DIFF
--- a/src/Test/AbstractBlockServiceTestCase.php
+++ b/src/Test/AbstractBlockServiceTestCase.php
@@ -13,91 +13,20 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Test;
 
-use PHPUnit\Framework\TestCase;
-use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\BlockContextManager;
-use Sonata\BlockBundle\Block\BlockContextManagerInterface;
-use Sonata\BlockBundle\Block\BlockServiceInterface;
-use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+@trigger_error(
+    'The '.__NAMESPACE__.'\AbstractBlockServiceTestCase class is deprecated since sonata-project/block-bundle 3.x '.
+    'and will be removed with the 4.0 release. '.
+    'Use '.__NAMESPACE__.'\BlockServiceTestCase instead.',
+    E_USER_DEPRECATED
+);
 
 /**
  * Abstract test class for block service tests.
  *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ *
+ * @deprecated since sonata-project/block-bundle 3.x, to be removed in 4.0. Use Sonata\BlockBundle\Test\BlockServiceTestCase instead.
  */
-abstract class AbstractBlockServiceTestCase extends TestCase
+abstract class AbstractBlockServiceTestCase extends BlockServiceTestCase
 {
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface
-     */
-    protected $container;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject|BlockServiceManagerInterface
-     */
-    protected $blockServiceManager;
-
-    /**
-     * @var BlockContextManagerInterface
-     */
-    protected $blockContextManager;
-
-    /**
-     * @var FakeTemplating
-     */
-    protected $templating;
-
-    protected function setUp()
-    {
-        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->templating = new FakeTemplating();
-
-        $blockLoader = $this->createMock('Sonata\BlockBundle\Block\BlockLoaderInterface');
-        $this->blockServiceManager = $this->createMock('Sonata\BlockBundle\Block\BlockServiceManagerInterface');
-        $this->blockContextManager = new BlockContextManager($blockLoader, $this->blockServiceManager);
-    }
-
-    /**
-     * Create a mocked block service.
-     *
-     * @param BlockServiceInterface $blockService A block service
-     *
-     * @return BlockContextInterface
-     */
-    protected function getBlockContext(BlockServiceInterface $blockService)
-    {
-        $this->blockServiceManager->expects($this->once())->method('get')->willReturn($blockService);
-
-        $block = $this->createMock('Sonata\BlockBundle\Model\BlockInterface');
-        $block->expects($this->once())->method('getSettings')->willReturn([]);
-
-        $blockContext = $this->blockContextManager->get($block);
-        $this->assertInstanceOf('Sonata\BlockBundle\Block\BlockContextInterface', $blockContext);
-
-        return $blockContext;
-    }
-
-    /**
-     * Asserts that the block settings have the expected values.
-     *
-     * @param array                 $expected     Expected settings
-     * @param BlockContextInterface $blockContext BlockContext object
-     */
-    protected function assertSettings(array $expected, BlockContextInterface $blockContext)
-    {
-        $completeExpectedOptions = array_merge([
-            'use_cache' => true,
-            'extra_cache_keys' => [],
-            'attr' => [],
-            'template' => false,
-            'ttl' => 0,
-        ], $expected);
-
-        ksort($completeExpectedOptions);
-        $blockSettings = $blockContext->getSettings();
-        ksort($blockSettings);
-
-        $this->assertSame($completeExpectedOptions, $blockSettings);
-    }
 }

--- a/src/Test/BlockServiceTestCase.php
+++ b/src/Test/BlockServiceTestCase.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Test;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\BlockContextManager;
+use Sonata\BlockBundle\Block\BlockContextManagerInterface;
+use Sonata\BlockBundle\Block\BlockLoaderInterface;
+use Sonata\BlockBundle\Block\BlockServiceInterface;
+use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
+use Sonata\BlockBundle\Model\BlockInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Abstract test class for block service tests.
+ *
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+abstract class BlockServiceTestCase extends TestCase
+{
+    /**
+     * @var MockObject|ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var MockObject|BlockServiceManagerInterface
+     */
+    protected $blockServiceManager;
+
+    /**
+     * @var BlockContextManagerInterface
+     */
+    protected $blockContextManager;
+
+    /**
+     * @var FakeTemplating
+     */
+    protected $templating;
+
+    protected function setUp()
+    {
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->templating = new FakeTemplating();
+
+        $blockLoader = $this->createMock(BlockLoaderInterface::class);
+        $this->blockServiceManager = $this->createMock(BlockServiceManagerInterface::class);
+        $this->blockContextManager = new BlockContextManager($blockLoader, $this->blockServiceManager);
+    }
+
+    /**
+     * Create a mocked block service.
+     */
+    protected function getBlockContext(BlockServiceInterface $blockService): BlockContextInterface
+    {
+        $this->blockServiceManager->expects($this->once())->method('get')->willReturn($blockService);
+
+        $block = $this->createMock(BlockInterface::class);
+        $block->expects($this->once())->method('getSettings')->willReturn([]);
+
+        $blockContext = $this->blockContextManager->get($block);
+        $this->assertInstanceOf(BlockContextInterface::class, $blockContext);
+
+        return $blockContext;
+    }
+
+    /**
+     * Asserts that the block settings have the expected values.
+     *
+     * @param array $expected Expected settings
+     */
+    protected function assertSettings(array $expected, BlockContextInterface $blockContext): void
+    {
+        $completeExpectedOptions = array_merge([
+            'use_cache' => true,
+            'extra_cache_keys' => [],
+            'attr' => [],
+            'template' => false,
+            'ttl' => 0,
+        ], $expected);
+
+        ksort($completeExpectedOptions);
+        $blockSettings = $blockContext->getSettings();
+        ksort($blockSettings);
+
+        $this->assertSame($completeExpectedOptions, $blockSettings);
+    }
+}

--- a/tests/Block/Service/MenuBlockServiceTest.php
+++ b/tests/Block/Service/MenuBlockServiceTest.php
@@ -16,14 +16,14 @@ namespace Sonata\BlockBundle\Tests\Block\Service;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\Service\MenuBlockService;
 use Sonata\BlockBundle\Menu\MenuRegistryInterface;
-use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\Form\Type\ImmutableArrayType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormTypeInterface;
 
-final class MenuBlockServiceTest extends AbstractBlockServiceTestCase
+final class MenuBlockServiceTest extends BlockServiceTestCase
 {
     /**
      * @var MenuProviderInterface

--- a/tests/Block/Service/RssBlockServiceTest.php
+++ b/tests/Block/Service/RssBlockServiceTest.php
@@ -16,10 +16,10 @@ namespace Sonata\BlockBundle\Tests\Block\Service;
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Block\Service\RssBlockService;
 use Sonata\BlockBundle\Model\Block;
-use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\BlockBundle\Util\OptionsResolver;
 
-final class RssBlockServiceTest extends AbstractBlockServiceTestCase
+final class RssBlockServiceTest extends BlockServiceTestCase
 {
     /*
      * only test if the API is not broken

--- a/tests/Block/Service/TextBlockServiceTest.php
+++ b/tests/Block/Service/TextBlockServiceTest.php
@@ -16,10 +16,10 @@ namespace Sonata\BlockBundle\Tests\Block\Service;
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Block\Service\TextBlockService;
 use Sonata\BlockBundle\Model\Block;
-use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\BlockBundle\Util\OptionsResolver;
 
-final class TextBlockServiceTest extends AbstractBlockServiceTestCase
+final class TextBlockServiceTest extends BlockServiceTestCase
 {
     public function testService()
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This class is loaded inside the prod autoloader, we should handle this as a `minor` change.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #425

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `AbstractBlockServiceTestCase` class with `BlockServiceTestCase`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
