### PR TITLE
Deprecated block id

### DIFF
--- a/src/Block/BlockContextManager.php
+++ b/src/Block/BlockContextManager.php
@@ -141,8 +141,8 @@ class BlockContextManager implements BlockContextManagerInterface
         } catch (ExceptionInterface $e) {
             if ($this->logger) {
                 $this->logger->error(sprintf(
-                    '[cms::blockContext] block.id=%s - error while resolving options - %s',
-                    $block->getId(),
+                    '[cms::blockContext] block.name=%s - error while resolving options - %s',
+                    $block->getName(),
                     $e->getMessage()
                 ));
             }

--- a/src/Block/BlockRenderer.php
+++ b/src/Block/BlockRenderer.php
@@ -76,7 +76,7 @@ class BlockRenderer implements BlockRendererInterface
         $block = $blockContext->getBlock();
 
         if ($this->logger) {
-            $this->logger->info(sprintf('[cms::renderBlock] block.id=%d, block.type=%s ', $block->getId(), $block->getType()));
+            $this->logger->info(sprintf('[cms::renderBlock] block.name=%d, block.type=%s ', $block->getName(), $block->getType()));
         }
 
         try {
@@ -95,8 +95,8 @@ class BlockRenderer implements BlockRendererInterface
         } catch (\Exception $exception) {
             if ($this->logger) {
                 $this->logger->error(sprintf(
-                    '[cms::renderBlock] block.id=%d - error while rendering block - %s',
-                    $block->getId(),
+                    '[cms::renderBlock] block.name=%d - error while rendering block - %s',
+                    $block->getName(),
                     $exception->getMessage()
                 ), compact('exception'));
             }

--- a/src/Model/Block.php
+++ b/src/Model/Block.php
@@ -20,6 +20,9 @@ class Block extends BaseBlock
 {
     /**
      * @var mixed
+     *
+     * @deprecated since sonata-project/block-bundle 3.x, to be removed in 4.0.
+     *             You should implement the id inside your bundle.
      */
     protected $id;
 

--- a/src/Model/BlockInterface.php
+++ b/src/Model/BlockInterface.php
@@ -22,6 +22,9 @@ interface BlockInterface
      * Sets the block Id.
      *
      * @param mixed $id
+     *
+     * @deprecated since sonata-project/block-bundle 3.x, to be removed in 4.0.
+     *             You should implement the id inside your bundle.
      */
     public function setId($id);
 
@@ -29,6 +32,9 @@ interface BlockInterface
      * Returns the block id.
      *
      * @return mixed void
+     *
+     * @deprecated since sonata-project/block-bundle 3.x, to be removed in 4.0.
+     *             You should implement the id inside your bundle.
      */
     public function getId();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

We only use the `id` for logging, debug information and cache key generation

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #561

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated block id
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
-->

## To do
 - [ ] Find a solution for the cache key
