### PR TITLE
Deprecated JMS annotations

### DIFF
--- a/docs/reference/annotations.rst
+++ b/docs/reference/annotations.rst
@@ -1,6 +1,10 @@
 Annotations
 ===========
 
+.. note::
+
+    Block annotations are deprecated, because they are not working with upcoming symfony releases.
+
 All annotations require jms/di-extra-bundle, it can easily be installed by composer:
 
 .. code-block:: bash

--- a/src/Annotation/Block.php
+++ b/src/Annotation/Block.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @Annotation
  * @Target("CLASS")
+ *
+ * @deprecated since sonata-project/block-bundle 3.x, to be removed in 4.0.
  */
 class Block implements MetadataProcessorInterface
 {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There is no symfony 4 support, and the projects looks dead :(

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated JMS annotations
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
