### PR TITLE
Deprecate "sonata.templating" service

### DIFF
--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -4,14 +4,17 @@
         <service id="sonata.templating.locator" class="Sonata\BlockBundle\Templating\TemplateLocator">
             <argument type="service" id="file_locator"/>
             <argument>%kernel.cache_dir%</argument>
+            <deprecated>The "%service_id%" service is deprecated since sonata-project/block-bundle 3.x and will be removed in version 4.0.</deprecated>
         </service>
         <service id="sonata.templating.name_parser" class="Sonata\BlockBundle\Templating\TemplateNameParser">
             <argument type="service" id="kernel"/>
+            <deprecated>The "%service_id%" service is deprecated since sonata-project/block-bundle 3.x and will be removed in version 4.0.</deprecated>
         </service>
         <service id="sonata.templating" class="Sonata\BlockBundle\Templating\TwigEngine">
             <argument type="service" id="twig"/>
             <argument type="service" id="sonata.templating.name_parser"/>
             <argument type="service" id="sonata.templating.locator"/>
+            <deprecated>The "%service_id%" service is deprecated since sonata-project/block-bundle 3.x and will be removed in version 4.0.</deprecated>
         </service>
         <service id="sonata.block.manager" class="Sonata\BlockBundle\Block\BlockServiceManager" public="true">
             <argument type="service" id="service_container"/>

--- a/src/Test/BlockServiceTestCase.php
+++ b/src/Test/BlockServiceTestCase.php
@@ -23,6 +23,7 @@ use Sonata\BlockBundle\Block\BlockServiceInterface;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Twig\Environment;
 
 /**
  * Abstract test class for block service tests.
@@ -49,9 +50,16 @@ abstract class InternalBlockServiceTestCase extends TestCase
     protected $blockContextManager;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var FakeTemplating
      */
     protected $templating;
+
+    /**
+     * @var Environment
+     */
+    protected $twig;
 
     /**
      * @internal
@@ -59,11 +67,13 @@ abstract class InternalBlockServiceTestCase extends TestCase
     protected function internalSetUp(): void
     {
         $this->container = $this->createMock(ContainerInterface::class);
+        // NEXT_MAJOR: Remove the following assignment.
         $this->templating = new FakeTemplating();
 
         $blockLoader = $this->createMock(BlockLoaderInterface::class);
         $this->blockServiceManager = $this->createMock(BlockServiceManagerInterface::class);
         $this->blockContextManager = new BlockContextManager($blockLoader, $this->blockServiceManager);
+        $this->twig = $this->createMock(Environment::class);
     }
 
     /**

--- a/src/Test/FakeTemplating.php
+++ b/src/Test/FakeTemplating.php
@@ -16,8 +16,18 @@ namespace Sonata\BlockBundle\Test;
 use Sonata\BlockBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\FakeTemplating class is deprecated since 3.x '.
+    'and will be removed in version 4.0.',
+    E_USER_DEPRECATED
+);
+
 /**
  * Mocking class for template usage.
+ *
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/block-bundle 3.x, will be removed in version 4.0.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */

--- a/tests/Block/Service/CustomBlockServiceTest.php
+++ b/tests/Block/Service/CustomBlockServiceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Block\Service;
+
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Test\BlockServiceTestCase;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+final class CustomBlockServiceTest extends BlockServiceTestCase
+{
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation Passing string as argument 1 to Sonata\BlockBundle\Block\Service\AbstractBlockService@anonymous::__construct() is deprecated since sonata-project/block-bundle 3.16 and will throw a \TypeError as of 4.0. You must pass an instance of Twig\Environment instead.
+     */
+    public function testArgumentDeprecation()
+    {
+        new class('block') extends AbstractBlockService {
+        };
+    }
+}

--- a/tests/Block/Service/EmptyBlockServiceTest.php
+++ b/tests/Block/Service/EmptyBlockServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Tests\Block\Service;
+
+use Sonata\BlockBundle\Block\Service\EmptyBlockService;
+use Sonata\BlockBundle\Test\BlockServiceTestCase;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+final class EmptyBlockServiceTest extends BlockServiceTestCase
+{
+    /**
+     * NEXT_MAJOR: Remove this test.
+     */
+    public function testArgumentCheck()
+    {
+        new EmptyBlockService($this->twig);
+        new EmptyBlockService($this->templating);
+        new EmptyBlockService('sonata.page.block.rss');
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument 1 passed to Sonata\BlockBundle\Block\Service\EmptyBlockService::__construct() must be a string or an instance of Twig\Environment or Symfony\Bundle\FrameworkBundle\Templating\EngineInterface, instance of stdClass given.');
+        new EmptyBlockService(new \stdClass());
+    }
+}

--- a/tests/Block/Service/MenuBlockServiceTest.php
+++ b/tests/Block/Service/MenuBlockServiceTest.php
@@ -35,6 +35,11 @@ final class MenuBlockServiceTest extends BlockServiceTestCase
      */
     private $menuRegistry;
 
+    /**
+     * NEXT_MAJOR: Remove the "legacy" group.
+     *
+     * @group legacy
+     */
     protected function setUp()
     {
         parent::setUp();

--- a/tests/Block/Service/RssBlockServiceTest.php
+++ b/tests/Block/Service/RssBlockServiceTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Tests\Block\Service;
 
+use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Block\Service\RssBlockService;
 use Sonata\BlockBundle\Model\Block;
@@ -21,10 +22,42 @@ use Sonata\BlockBundle\Util\OptionsResolver;
 
 final class RssBlockServiceTest extends BlockServiceTestCase
 {
-    /*
-     * only test if the API is not broken
+    /**
+     * only test if the API is not broken.
      */
     public function testService()
+    {
+        // NEXT_MAJOR: Remove the second argument
+        $service = new RssBlockService($this->twig, $this->templating);
+
+        $block = new Block();
+        $block->setType('core.text');
+        $block->setSettings([
+            'content' => 'my text',
+        ]);
+
+        $optionResolver = new OptionsResolver();
+        $service->setDefaultSettings($optionResolver);
+
+        $blockContext = new BlockContext($block, $optionResolver->resolve());
+
+        $formMapper = $this->createMock(FormMapper::class);
+        $formMapper->expects($this->exactly(2))->method('add');
+
+        $service->buildCreateForm($formMapper, $block);
+        $service->buildEditForm($formMapper, $block);
+
+        $service->execute($blockContext);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation Method Sonata\BlockBundle\Block\Service\RssBlockService::getTemplating() is deprecated since sonata-project/block-bundle 3.%s and will be removed as of version 4.0.
+     */
+    public function testGetTemplatingDeprecation()
     {
         $service = new RssBlockService('sonata.page.block.rss', $this->templating);
 
@@ -39,9 +72,7 @@ final class RssBlockServiceTest extends BlockServiceTestCase
 
         $blockContext = new BlockContext($block, $optionResolver->resolve());
 
-        $formMapper = $this->getMockBuilder('Sonata\\AdminBundle\\Form\\FormMapper')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $formMapper = $this->createMock(FormMapper::class);
         $formMapper->expects($this->exactly(2))->method('add');
 
         $service->buildCreateForm($formMapper, $block);

--- a/tests/Block/Service/TextBlockServiceTest.php
+++ b/tests/Block/Service/TextBlockServiceTest.php
@@ -21,6 +21,11 @@ use Sonata\BlockBundle\Util\OptionsResolver;
 
 final class TextBlockServiceTest extends BlockServiceTestCase
 {
+    /**
+     * NEXT_MAJOR: Remove the "legacy" group.
+     *
+     * @group legacy
+     */
     public function testService()
     {
         $service = new TextBlockService('sonata.page.block.text', $this->templating);

--- a/tests/Test/FakeTemplatingTest.php
+++ b/tests/Test/FakeTemplatingTest.php
@@ -16,6 +16,11 @@ namespace Sonata\BlockBundle\Tests\Test;
 use PHPUnit\Framework\TestCase;
 use Sonata\BlockBundle\Test\FakeTemplating;
 
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/block-bundle 3.x, will be removed in version 4.0.
+ */
 final class FakeTemplatingTest extends TestCase
 {
     public function testRender()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Deprecate "sonata.templating" service
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- "sonata.templating", "sonata.templating.locator" and "sonata.templating.name_parser" services;
- `Sonata\BlockBundle\Templating\TwigEngine` and `Sonata\BlockBundle\Test\FakeTemplating` classes.
```

## To do
    
- [x] Add tests.