### PR TITLE
Explicit call `__construct()` method in `DebugBlocksCommand`

### DIFF
--- a/src/Command/DebugBlocksCommand.php
+++ b/src/Command/DebugBlocksCommand.php
@@ -33,6 +33,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
      */
     protected static $defaultName = 'sonata:block:debug';
 
+    public function __construct(string $name = null, BlockServiceManagerInterface $blockManager)
+    {
+        parent::__construct($name, $blockManager);
+    }
+
     public function configure()
     {
         $this->setName(static::$defaultName); // BC for symfony/console < 3.4.0

--- a/src/Command/DebugBlocksCommand.php
+++ b/src/Command/DebugBlocksCommand.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Command;
 
+use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -24,7 +26,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * NEXT_MAJOR: Uncomment the "final" class declaration
  */
-/* final */class DebugBlocksCommand extends BaseCommand
+/* final */class DebugBlocksCommand extends Command
 {
     /**
      * {@inheritdoc}
@@ -33,9 +35,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
      */
     protected static $defaultName = 'sonata:block:debug';
 
+    /**
+     * @var BlockServiceManagerInterface
+     */
+    private $blockManager;
+
     public function __construct(string $name = null, BlockServiceManagerInterface $blockManager)
     {
-        parent::__construct($name, $blockManager);
+        $this->blockManager = $blockManager;
+
+        parent::__construct($name);
     }
 
     public function configure()

--- a/tests/Command/DebugBlocksCommandTest.php
+++ b/tests/Command/DebugBlocksCommandTest.php
@@ -75,30 +75,6 @@ final class DebugBlocksCommandTest extends TestCase
 
     /**
      * @group legacy
-     *
-     * @expectedDeprecation Method Sonata\BlockBundle\Command\DebugBlocksCommand::getBlockServiceManager() is deprecated since sonata-project/block-bundle 3.16 and will be removed with the 4.0 release.Use the Sonata\BlockBundle\Command\DebugBlocksCommand::$blockManager property instead.
-     */
-    public function testGetBlockServiceManager(): void
-    {
-        $blockManager = $this->createMock(BlockServiceManagerInterface::class);
-        $blockManager
-            ->expects($this->any())
-            ->method('getServices')
-            ->willReturn([]);
-
-        (new DebugBlocksCommand(null, $blockManager))->getBlockServiceManager();
-    }
-
-    public function testConstructorArguments(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Argument 2 passed to Sonata\BlockBundle\Command\DebugBlocksCommand::__construct() must be an instance of Sonata\BlockBundle\Block\BlockServiceManagerInterface, NULL given.');
-
-        new DebugBlocksCommand();
-    }
-
-    /**
-     * @group legacy
      */
     public function testDebugBlocks(): void
     {


### PR DESCRIPTION
This fixes issue when dependency injection was not providing required service but called default parent `__construct()` which has always `null` as second argument.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is bugfix.

Closes #624

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed

Prevent calling default `BaseCommand::__construct()` with default arguments, blocking extending commands from being properly registered. #624 

