### PR TITLE
Make cache optional again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "php": "^7.1",
         "doctrine/common": "^2.3",
         "psr/cache": "^1.0",
-        "psr/cache-implementation": "*",
         "sonata-project/cache": "^1.0 || ^2.0",
         "sonata-project/core-bundle": "^3.15.1",
         "sonata-project/doctrine-extensions": "^1.1",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
 The old sonata cache was optional (https://github.com/sonata-project/SonataBlockBundle/blob/3.17.0/src/Templating/Helper/BlockHelper.php#L89), so we should not force the user to use a cache.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a fixup of #628.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Make cache optional again
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
