### PR TITLE
CategoriesMenuBlockService (ecommerce)- side menu used by ProductBundle front page

### DIFF
--- a/src/Resources/views/Block/block_side_menu_template.html.twig
+++ b/src/Resources/views/Block/block_side_menu_template.html.twig
@@ -11,8 +11,9 @@ file that was distributed with this source code.
 
 {% extends 'knp_menu.html.twig' %}
 
-{% block list %}
 {% import 'knp_menu.html.twig' as macros %}
+
+{% block list %}
     {% if item.hasChildren and options.depth is not same as(0) and item.displayChildren %}
         <div{{ macros.attributes(listAttributes) }}>
             {{ block('children') }}
@@ -21,7 +22,6 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block item %}
-{% import 'knp_menu.html.twig' as macros %}
     {% if item.displayed %}
         {# building the class of the item #}
         {%- set classes = item.attribute('class') is not empty ? [item.attribute('class')] : [] %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

this PR is milestone to be able using sonata/ecommerce on Symfony 4.1

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

Closes #637 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Crash when attempting to display the side menu when using sonata/ecommerce and Symfony 4.1
```
