### PR TITLE
Added phpstan checks

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,12 @@
+on: [push, pull_request]
+name: Quality assurance
+jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: PHPStan
+        uses: "docker://oskarstark/phpstan-ga"
+        with:
+          args: analyse

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,19 @@
+parameters:
+    level: 2
+
+    paths:
+        - src
+# Uncomment this, when phpstan extensions are allowed
+#        - tests
+
+    excludes_analyse:
+        - src/Test/BlockServiceTestCase.php
+        - tests/bootstrap.php
+
+    autoload_files:
+        - vendor/autoload.php
+
+    ignoreErrors:
+        - '#Call to an undefined method Sonata\\Form\\Validator\\ErrorElement::assert.*\(\).#'
+        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::fixXmlConfig\(\).#'
+        - '#Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required.#'


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Improve code quality by running phpstan 🚀 

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC, but should only be done for the next major version.

This is the same PR like #611. It looks like GitHub can't add new hooks with existing PRs.