### PR TITLE
Dropping support for symfony < 4.3

### DIFF
--- a/src/Block/Service/MenuBlockService.php
+++ b/src/Block/Service/MenuBlockService.php
@@ -26,7 +26,6 @@ use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Twig\Environment;
@@ -128,11 +127,6 @@ final class MenuBlockService extends AbstractBlockService implements EditableBlo
             'label' => 'form.label_url',
             'choice_translation_domain' => 'SonataBlockBundle',
         ];
-
-        // choice_as_value options is not needed in SF 3.0+
-        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
-            $choiceOptions['choices_as_values'] = true;
-        }
 
         $choiceOptions['choices'] = array_flip($this->menuRegistry->getAliasNames());
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -38,12 +38,7 @@ final class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('sonata_block');
 
-        // Keep compatibility with symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $node = $treeBuilder->root('sonata_block');
-        } else {
-            $node = $treeBuilder->getRootNode();
-        }
+        $node = $treeBuilder->getRootNode();
 
         $node
             ->fixXmlConfig('default_context')

--- a/src/Form/Type/ContainerTemplateType.php
+++ b/src/Form/Type/ContainerTemplateType.php
@@ -37,11 +37,6 @@ final class ContainerTemplateType extends AbstractType
         return 'sonata_type_container_template_choice';
     }
 
-    public function getName()
-    {
-        return $this->getBlockPrefix();
-    }
-
     public function getParent()
     {
         return ChoiceType::class;

--- a/src/Form/Type/ServiceListType.php
+++ b/src/Form/Type/ServiceListType.php
@@ -34,11 +34,6 @@ final class ServiceListType extends AbstractType
         return 'sonata_block_service_choice';
     }
 
-    public function getName()
-    {
-        return $this->getBlockPrefix();
-    }
-
     public function getParent()
     {
         return ChoiceType::class;

--- a/tests/Block/Service/MenuBlockServiceTest.php
+++ b/tests/Block/Service/MenuBlockServiceTest.php
@@ -23,7 +23,6 @@ use Sonata\Form\Type\ImmutableArrayType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\FormTypeInterface;
 
 final class MenuBlockServiceTest extends BlockServiceTestCase
 {
@@ -65,11 +64,6 @@ final class MenuBlockServiceTest extends BlockServiceTestCase
         ];
 
         $choices = ['Test Menu' => 'acme:demobundle:menu'];
-
-        // choice_as_value options is not needed in SF 3.0+
-        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
-            $choiceOptions['choices_as_values'] = true;
-        }
 
         $choiceOptions['choices'] = [
             'Test Menu' => 'acme:demobundle:menu',

--- a/tests/DependencyInjection/Compiler/TweakCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/TweakCompilerPassTest.php
@@ -46,12 +46,6 @@ final class TweakCompilerPassTest extends TestCase
 
     public function testProcessAutowired(): void
     {
-        if (!method_exists(Definition::class, 'setAutoconfigured')) {
-            $this->markTestSkipped(
-              'Autowiring does not exist in < symfony 3.'
-            );
-        }
-
         $blockDefinition = new Definition(null, ['acme.block.service']);
         $blockDefinition->addTag('sonata.block');
         $blockDefinition->setAutoconfigured(true);

--- a/tests/Form/Type/ServiceListTypeTest.php
+++ b/tests/Form/Type/ServiceListTypeTest.php
@@ -29,7 +29,7 @@ final class ServiceListTypeTest extends TestCase
             $this->createMock(BlockServiceManagerInterface::class)
         );
 
-        $this->assertSame('sonata_block_service_choice', $type->getName());
+        $this->assertSame('sonata_block_service_choice', $type->getBlockPrefix());
         $this->assertSame(ChoiceType::class, $type->getParent());
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a cleanup for old code.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove old symfony < 4.3 code
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
