### PR TITLE
Remove current timestamp from cache key

### DIFF
--- a/src/Block/Service/AbstractBlockService.php
+++ b/src/Block/Service/AbstractBlockService.php
@@ -69,7 +69,7 @@ abstract class AbstractBlockService implements BlockServiceInterface
     {
         return [
             'block_id' => $block->getId(),
-            'updated_at' => null !== $block->getUpdatedAt() ? $block->getUpdatedAt()->format('U') : strtotime('now'),
+            'updated_at' => null !== $block->getUpdatedAt() ? $block->getUpdatedAt()->format('U') : null,
         ];
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a soft BC break, because it removes the dynamic timestamp from the cache key.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #329 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Remove current timestamp from cache key
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
