### PR TITLE
Remove test deprecation

### DIFF
--- a/src/Test/BlockServiceTestCase.php
+++ b/src/Test/BlockServiceTestCase.php
@@ -50,16 +50,28 @@ abstract class InternalBlockServiceTestCase extends TestCase
     protected $blockContextManager;
 
     /**
-     * NEXT_MAJOR: Remove this property.
-     *
-     * @var FakeTemplating
-     */
-    protected $templating;
-
-    /**
      * @var Environment
      */
     protected $twig;
+
+    /**
+     * NEXT_MAJOR: Remove this property.
+     */
+    private $internalTemplating;
+
+    /**
+     * NEXT_MAJOR: Remove this property hack.
+     */
+    public function __get($name)
+    {
+        if ('templating' === $name) {
+            if (null === $this->internalTemplating) {
+                $this->internalTemplating = new FakeTemplating();
+            }
+
+            return $this->internalTemplating;
+        }
+    }
 
     /**
      * @internal
@@ -67,8 +79,6 @@ abstract class InternalBlockServiceTestCase extends TestCase
     protected function internalSetUp(): void
     {
         $this->container = $this->createMock(ContainerInterface::class);
-        // NEXT_MAJOR: Remove the following assignment.
-        $this->templating = new FakeTemplating();
 
         $blockLoader = $this->createMock(BlockLoaderInterface::class);
         $this->blockServiceManager = $this->createMock(BlockServiceManagerInterface::class);

--- a/tests/Block/Service/EmptyBlockServiceTest.php
+++ b/tests/Block/Service/EmptyBlockServiceTest.php
@@ -23,15 +23,44 @@ final class EmptyBlockServiceTest extends BlockServiceTestCase
 {
     /**
      * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
      */
-    public function testArgumentCheck()
+    public function testInvalidConstructor(): void
     {
-        new EmptyBlockService($this->twig);
-        new EmptyBlockService($this->templating);
-        new EmptyBlockService('sonata.page.block.rss');
-
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('Argument 1 passed to Sonata\BlockBundle\Block\Service\EmptyBlockService::__construct() must be a string or an instance of Twig\Environment or Symfony\Component\Templating\EngineInterface, instance of stdClass given.');
+
         new EmptyBlockService(new \stdClass());
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testDeprecatedStringConstructor(): void
+    {
+        new EmptyBlockService('sonata.page.block.empty');
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
+     * @expectedDeprecation The Sonata\BlockBundle\Test\FakeTemplating class is deprecated since 3.17 and will be removed in version 4.0.
+     */
+    public function testDeprecatedTemplatingConstructor(): void
+    {
+        new EmptyBlockService($this->templating);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     */
+    public function testValiConstructor(): void
+    {
+        new EmptyBlockService($this->twig);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Just calling the `setUp` method was throwing a deprecation warning. The deprecation is now thrown, when someone accesses the `templating` property.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because we must maintain the old 3.x branch because we still use it for most of our bundles.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed deprecation warnings when extending `BlockServiceTestCase`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
