### PR TITLE
Lazy loaded Block Extension

### DIFF
--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -25,6 +25,7 @@
             <argument type="service" id="sonata.block.templating.helper"/>
         </service>
         <service id="sonata.block.templating.helper" class="Sonata\BlockBundle\Templating\Helper\BlockHelper">
+            <tag name="twig.runtime"/>
             <argument type="service" id="sonata.block.manager"/>
             <argument>%sonata_block.cache_blocks%</argument>
             <argument type="service" id="sonata.block.renderer"/>
@@ -34,6 +35,7 @@
             <argument type="service" id="sonata.block.cache.handler.default" on-invalid="ignore"/>
             <argument type="service" id="debug.stopwatch" on-invalid="ignore"/>
         </service>
+        <service id="Sonata\BlockBundle\Templating\Helper\BlockHelper" alias="sonata.block.templating.helper"/>
         <service id="sonata.block.loader.chain" class="Sonata\BlockBundle\Block\BlockLoaderChain">
             <argument/>
         </service>

--- a/src/Twig/Extension/BlockExtension.php
+++ b/src/Twig/Extension/BlockExtension.php
@@ -19,41 +19,31 @@ use Twig\TwigFunction;
 
 final class BlockExtension extends AbstractExtension
 {
-    /**
-     * @var BlockHelper
-     */
-    private $blockHelper;
-
-    public function __construct(BlockHelper $blockHelper)
-    {
-        $this->blockHelper = $blockHelper;
-    }
-
     public function getFunctions()
     {
         return [
             new TwigFunction(
                 'sonata_block_exists',
-                [$this->blockHelper, 'exists']
+                [BlockHelper::class, 'exists']
             ),
             new TwigFunction(
                 'sonata_block_render',
-                [$this->blockHelper, 'render'],
+                [BlockHelper::class, 'render'],
                 ['is_safe' => ['html']]
             ),
             new TwigFunction(
                 'sonata_block_render_event',
-                [$this->blockHelper, 'renderEvent'],
+                [BlockHelper::class, 'renderEvent'],
                 ['is_safe' => ['html']]
             ),
             new TwigFunction(
                 'sonata_block_include_javascripts',
-                [$this->blockHelper, 'includeJavascripts'],
+                [BlockHelper::class, 'includeJavascripts'],
                 ['is_safe' => ['html']]
             ),
             new TwigFunction(
                 'sonata_block_include_stylesheets',
-                [$this->blockHelper, 'includeStylesheets'],
+                [BlockHelper::class, 'includeStylesheets'],
                 ['is_safe' => ['html']]
             ),
         ];


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a BC feature which makes the BlockExtension [lazy](https://symfony.com/doc/current/templating/twig_extension.html#creating-lazy-loaded-twig-extensions).

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #675 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
* Lazy `BlockExtension` to speed Twig initialization
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
