### PR TITLE
Drop unnesessary constructor

### DIFF
--- a/src/Block/BlockContextManager.php
+++ b/src/Block/BlockContextManager.php
@@ -153,7 +153,7 @@ class BlockContextManager implements BlockContextManagerInterface
      */
     protected function setDefaultSettings(OptionsResolverInterface $optionsResolver, BlockInterface $block)
     {
-        if (__CLASS__ !== \get_called_class()) {
+        if (__CLASS__ !== static::class) {
             @trigger_error(
                 'The '.__METHOD__.' is deprecated since version 2.3, to be renamed in 4.0.'
                 .' Use '.__CLASS__.'::configureSettings instead.',

--- a/src/Block/Service/AbstractAdminBlockService.php
+++ b/src/Block/Service/AbstractAdminBlockService.php
@@ -17,7 +17,6 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Validator\ErrorElement;
-use Symfony\Component\Templating\EngineInterface;
 
 @trigger_error(
     'The '.__NAMESPACE__.'\AbstractAdminBlockService class is deprecated since sonata-project/block-bundle 3.16 '.
@@ -32,14 +31,6 @@ use Symfony\Component\Templating\EngineInterface;
  */
 abstract class AbstractAdminBlockService extends AbstractBlockService implements AdminBlockServiceInterface
 {
-    /**
-     * @param string $name
-     */
-    public function __construct($name, EngineInterface $templating)
-    {
-        parent::__construct($name, $templating);
-    }
-
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
         $this->buildEditForm($formMapper, $block);

--- a/src/Block/Service/AbstractBlockService.php
+++ b/src/Block/Service/AbstractBlockService.php
@@ -48,7 +48,7 @@ abstract class AbstractBlockService implements BlockServiceInterface
      *
      * @param Environment|EngineInterface|string $templatingOrDeprecatedName
      */
-    public function __construct($templatingOrDeprecatedName = null, EngineInterface $templating = null)
+    public function __construct($templatingOrDeprecatedName = null, ?EngineInterface $templating = null)
     {
         // $this->twig = $twig;
         // NEXT_MAJOR: Uncomment the previous assignment and remove the following lines in this method.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This change will allow prepare blocks which extends `AbstractAdminBlockService` to use one parameter constructor required in BlockBundle 4.x
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is PATCH.