### PR TITLE
Fix autowired service id mismatch

### DIFF
--- a/src/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\DependencyInjection\Compiler;
 
-use Sonata\BlockBundle\Naming\ConvertFromFqcn;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -46,18 +45,17 @@ class TweakCompilerPass implements CompilerPassInterface
                 $this->replaceBlockName($container, $definition, $id);
             }
 
-            $blockId = $this->getBlockId($id);
             $settings = $this->createBlockSettings($id, $tags, $defaultContexs);
 
             // Register blocks dynamicaly
-            if (!\array_key_exists($blockId, $blocks)) {
-                $blocks[$blockId] = $settings;
+            if (!\array_key_exists($id, $blocks)) {
+                $blocks[$id] = $settings;
             }
-            if (!\in_array($blockId, $blockTypes, true)) {
-                $blockTypes[] = $blockId;
+            if (!\in_array($id, $blockTypes, true)) {
+                $blockTypes[] = $id;
             }
-            if (isset($cacheBlocks['by_type']) && !\array_key_exists($blockId, $cacheBlocks['by_type'])) {
-                $cacheBlocks['by_type'][$blockId] = $settings['cache'];
+            if (isset($cacheBlocks['by_type']) && !\array_key_exists($id, $cacheBlocks['by_type'])) {
+                $cacheBlocks['by_type'][$id] = $settings['cache'];
             }
 
             $manager->addMethodCall('add', [$id, $id, $settings['contexts']]);
@@ -104,19 +102,6 @@ class TweakCompilerPass implements CompilerPassInterface
                 $definition->addMethodCall('addSettingsByClass', [$class, $settings['settings'], true]);
             }
         }
-    }
-
-    private function getBlockId(string $id): string
-    {
-        $blockId = $id;
-
-        // Only convert class service names
-        if (false !== strpos($blockId, '\\')) {
-            $convert = (new ConvertFromFqcn());
-            $blockId = $convert($blockId);
-        }
-
-        return $blockId;
     }
 
     private function createBlockSettings(string $id, array $tags = [], array $defaultContexts = []): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is a backport of a bugfix (#646). The registered block id must match with the service id.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix autowired service id mismatch
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
