### PR TITLE
Support doctrine/common 3 in 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     ],
     "require": {
         "php": "^7.1",
-        "doctrine/common": "^2.3",
+        "doctrine/collections": "^1.6",
+        "doctrine/common": "^2.3 || ^3.0",
         "psr/cache": "^1.0",
         "sonata-project/cache": "^1.0 || ^2.0",
         "sonata-project/core-bundle": "^3.15.1",


### PR DESCRIPTION
## Subject

This PR adds support for `doctrine/common` 3. It follows the upgrade instructions in Doctrine's [release notes](https://github.com/doctrine/common/releases/tag/3.0.0).

I am targeting this branch, as requested in #709

Also see corresponding PR for https://github.com/sonata-project/SonataAdminBundle/pull/6127.

## Changelog

```markdown
### Added
- Added support for `doctrine/common` 3.
```