### PR TITLE
Bump Symfony < 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,18 +27,18 @@
         "sonata-project/cache": "^1.0 || ^2.0",
         "sonata-project/doctrine-extensions": "^1.1",
         "sonata-project/form-extensions": "^0.1.1 || ^1.4",
-        "symfony/asset": "^4.3",
-        "symfony/config": "^4.3",
-        "symfony/console": "^4.3",
-        "symfony/dependency-injection": "^4.3",
-        "symfony/event-dispatcher": "^4.3",
-        "symfony/form": "^4.3",
-        "symfony/framework-bundle": "^4.3",
-        "symfony/http-foundation": "^4.3",
-        "symfony/http-kernel": "^4.3",
-        "symfony/options-resolver": "^4.3",
-        "symfony/templating": "^4.3",
-        "symfony/twig-bundle": "^4.3",
+        "symfony/asset": "^4.4",
+        "symfony/config": "^4.4",
+        "symfony/console": "^4.4",
+        "symfony/dependency-injection": "^4.4",
+        "symfony/event-dispatcher": "^4.4",
+        "symfony/form": "^4.4",
+        "symfony/framework-bundle": "^4.4",
+        "symfony/http-foundation": "^4.4",
+        "symfony/http-kernel": "^4.4",
+        "symfony/options-resolver": "^4.4",
+        "symfony/templating": "^4.4",
+        "symfony/twig-bundle": "^4.4",
         "twig/twig": "^2.12.1"
     },
     "conflict": {
@@ -49,9 +49,9 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpspec/prophecy": "^1.10",
         "sonata-project/admin-bundle": "^3.28",
-        "symfony/debug": "^4.3",
-        "symfony/phpunit-bridge": "^5.0",
-        "symfony/stopwatch": "^4.3"
+        "symfony/debug": "^4.4",
+        "symfony/phpunit-bridge": "^5.1",
+        "symfony/stopwatch": "^4.4"
     },
     "suggest": {
         "knplabs/knp-menu-bundle": "^2.2"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Some bundles like: NotificationBundle, DoctrineORMAdminBundle, PageBundle, SeoBundle, UserBundle using Symfony v4.4. To avoid situation like [here](https://github.com/sonata-project/SonataPageBundle/issues/1168#issuecomment-655587405) some bundles like this must bump Symfony < 4.4 too.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for Symfony < 4.4
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
