### PR TITLE
Added conflict for "knplabs/knp-menu-bundle:<3.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,10 +42,12 @@
         "twig/twig": "^2.12.1 || ^3.0"
     },
     "conflict": {
+        "knplabs/knp-menu-bundle": "<3.0",
         "sonata-project/core-bundle": "<3.20"
     },
     "require-dev": {
-        "knplabs/knp-menu-bundle": "^2.2",
+        "knplabs/knp-menu": "^3.1",
+        "knplabs/knp-menu-bundle": "^3.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpspec/prophecy": "^1.10",
         "sonata-project/admin-bundle": "^3.28",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Added conflict for "knplabs/knp-menu-bundle:<3.0".
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Triggered by https://github.com/sonata-project/SonataBlockBundle/pull/732#pullrequestreview-474163757.

## To do

- [x] Wait for a release of sonata-project/admin-bundle:3.75.0.
