### PR TITLE
Make MenuBlockService non-final

### DIFF
--- a/src/Block/Service/MenuBlockService.php
+++ b/src/Block/Service/MenuBlockService.php
@@ -33,7 +33,7 @@ use Twig\Environment;
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-final class MenuBlockService extends AbstractBlockService implements EditableBlockService
+class MenuBlockService extends AbstractBlockService implements EditableBlockService
 {
     /**
      * @var MenuProviderInterface


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This class is extended here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/src/Block/Breadcrumb/BaseBreadcrumbMenuBlockService.php

Defining breadcrumbs should be refactored somehow, but there are no good sultions for now.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Make `MenuBlockService` non-final
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
