### PR TITLE
Allow replace `AbstractAdminBlockService` by `EditableBlockService`

### DIFF
--- a/src/Block/Service/AbstractAdminBlockService.php
+++ b/src/Block/Service/AbstractAdminBlockService.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Block\Service;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\FormMapper as AdminFormMapper;
+use Sonata\BlockBundle\Form\Mapper\BlockFormMapper;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Validator\ErrorElement;
 
@@ -31,45 +34,97 @@ use Sonata\Form\Validator\ErrorElement;
  */
 abstract class AbstractAdminBlockService extends AbstractBlockService implements AdminBlockServiceInterface
 {
-    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
-    {
-        $this->buildEditForm($formMapper, $block);
-    }
-
+    /**
+     * @deprecated since sonata-project/block-bundle 3.12.0 and will be removed in version 4.0.
+     */
     public function prePersist(BlockInterface $block)
     {
     }
 
+    /**
+     * @deprecated since sonata-project/block-bundle 3.12.0 and will be removed in version 4.0.
+     */
     public function postPersist(BlockInterface $block)
     {
     }
 
+    /**
+     * @deprecated since sonata-project/block-bundle 3.12.0 and will be removed in version 4.0.
+     */
     public function preUpdate(BlockInterface $block)
     {
     }
 
+    /**
+     * @deprecated since sonata-project/block-bundle 3.12.0 and will be removed in version 4.0.
+     */
     public function postUpdate(BlockInterface $block)
     {
     }
 
+    /**
+     * @deprecated since sonata-project/block-bundle 3.12.0 and will be removed in version 4.0.
+     */
     public function preRemove(BlockInterface $block)
     {
     }
 
+    /**
+     * @deprecated since sonata-project/block-bundle 3.12.0 and will be removed in version 4.0.
+     */
     public function postRemove(BlockInterface $block)
     {
     }
 
-    public function buildEditForm(FormMapper $form, BlockInterface $block)
+    /**
+     * @deprecated since sonata-project/block-bundle 3.x. Use "configureCreateForm()" instead.
+     */
+    public function buildCreateForm(AdminFormMapper $formMapper, BlockInterface $block)
     {
+        $blockFormMapper = new BlockFormMapper($formMapper);
+        $this->configureCreateForm($blockFormMapper, $block);
     }
 
+    /**
+     * @deprecated since sonata-project/block-bundle 3.x. Use "configureEditForm()" instead.
+     */
+    public function buildEditForm(AdminFormMapper $formMapper, BlockInterface $block)
+    {
+        $blockFormMapper = new BlockFormMapper($formMapper);
+        $this->configureEditForm($blockFormMapper, $block);
+    }
+
+    /**
+     * @deprecated since sonata-project/block-bundle 3.x. Use "validate()" instead.
+     */
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
     {
+        $this->validate($errorElement, $block);
     }
 
+    /**
+     * @deprecated since sonata-project/block-bundle 3.x. Use "getMetadata()" instead.
+     */
     public function getBlockMetadata($code = null)
     {
         return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataBlockBundle', ['class' => 'fa fa-file']);
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block)
+    {
+    }
+
+    public function configureCreateForm(FormMapper $form, BlockInterface $block)
+    {
+        $this->configureEditForm($form, $block);
+    }
+
+    public function validate(ErrorElement $errorElement, BlockInterface $block)
+    {
+    }
+
+    public function getMetadata(): MetadataInterface
+    {
+        return new Metadata($this->getName(), $this->getName(), false, 'SonataBlockBundle', ['class' => 'fa fa-file']);
     }
 }

--- a/src/Form/Mapper/BlockFormMapper.php
+++ b/src/Form/Mapper/BlockFormMapper.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Form\Mapper;
+
+use Sonata\AdminBundle\Form\FormMapper as AdminFormMapper;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class BlockFormMapper implements FormMapper
+{
+    /**
+     * @var AdminFormMapper
+     */
+    private $adminFormMapper;
+
+    public function __construct(AdminFormMapper $adminFormMapper)
+    {
+        $this->adminFormMapper = $adminFormMapper;
+    }
+
+    public function create(string $name, ?string $type = null, array $options = []): FormBuilderInterface
+    {
+        return $this->adminFormMapper->create($name, $type, $options);
+    }
+
+    public function reorder(array $keys): FormMapper
+    {
+        $this->adminFormMapper->reorder($keys);
+
+        return $this;
+    }
+
+    public function add($name, ?string $type = null, array $options = []): FormMapper
+    {
+        $this->adminFormMapper->add($name, $type, $options);
+
+        return $this;
+    }
+
+    public function remove(string $key): FormMapper
+    {
+        $this->adminFormMapper->remove($key);
+
+        return $this;
+    }
+
+    public function setHelps(array $helps = []): FormMapper
+    {
+        $this->adminFormMapper->setHelps($helps);
+
+        return $this;
+    }
+
+    public function addHelp(string $name, string $help): FormMapper
+    {
+        $this->adminFormMapper->addHelp($name, $help);
+
+        return $this;
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->adminFormMapper->has($key);
+    }
+
+    public function get(string $name)
+    {
+        return $this->adminFormMapper->get($name);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

Based on https://github.com/sonata-project/dev-kit/issues/785 `AbstractAdminBlockService` should be replace by  `extends AbstractBlockService implements EditableBlockService`. To do it this methods should be replaced:
- `buildEditForm` => `configureEditForm`
- `buildCreateForm` => `confiureCreateForm`
- `validateBlock` => `validate`
- `getBlockMetadata` => `getMetadata`

This change will allow move code to new methods with keep BC. In second step in `4.x` branch we can add `AbstractAdminBlockService implement EditableBlockService`. In third step we can add support for BlockBundle v4 in sonata 3 (with some little BC-break).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\BlockBundle\Form\Mapper\BlockFormMapper` class for allow use `FormMapper` with AdminBundle
- Added some methods to `Sonata\BlockBundle\Block\Service\AbstractAdminBlockService` for feature compatibility:
    - `configureEditForm()`
    - `configureCreateForm()`
    - `validate()`
    - `getMetadata()`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
