### PR TITLE
Fix phpdoc

### DIFF
--- a/src/Test/BlockServiceTestCase.php
+++ b/src/Test/BlockServiceTestCase.php
@@ -33,12 +33,12 @@ use Twig\Environment;
 abstract class InternalBlockServiceTestCase extends TestCase
 {
     /**
-     * @var MockObject|ContainerInterface
+     * @var MockObject&ContainerInterface
      */
     protected $container;
 
     /**
-     * @var MockObject|BlockServiceManagerInterface
+     * @var MockObject&BlockServiceManagerInterface
      */
     protected $blockServiceManager;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

`&` should be used instead of `|` or we'll end with psalm errors.
(I got these on SonataAdminBundle).

## Changelog


<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `BlockServiceTestCase` phpdoc
```