### PR TITLE
Fix phpdoc

### DIFF
--- a/src/Test/BlockServiceTestCase.php
+++ b/src/Test/BlockServiceTestCase.php
@@ -37,7 +37,7 @@ use Twig\Environment;
 abstract class BlockServiceTestCase extends TestCase
 {
     /**
-     * @var MockObject|BlockServiceManagerInterface
+     * @var MockObject&BlockServiceManagerInterface
      */
     protected $blockServiceManager;
 
@@ -47,12 +47,12 @@ abstract class BlockServiceTestCase extends TestCase
     protected $blockContextManager;
 
     /**
-     * @var MockObject|Environment
+     * @var MockObject&Environment
      */
     protected $twig;
 
     /**
-     * @var MockObject|BlockInterface
+     * @var MockObject&BlockInterface
      */
     protected $block;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

`&` should be used instead of `|` or we'll end with psalm errors.
(I got these on SonataAdminBundle).

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `BlockServiceTestCase` phpdoc
```