### PR TITLE
Fix wrong child block type choice

### DIFF
--- a/src/Form/Type/ServiceListType.php
+++ b/src/Form/Type/ServiceListType.php
@@ -60,7 +60,7 @@ class ServiceListType extends AbstractType
             'choices' => static function (Options $options, $previousValue) use ($manager) {
                 $types = [];
                 foreach ($manager->getServicesByContext($options['context'], $options['include_containers']) as $code => $service) {
-                    $types[$code] = sprintf('%s - %s', $service->getName(), $code);
+                    $types[sprintf('%s - %s', $service->getName(), $code)] = $code;
                 }
 
                 return $types;

--- a/tests/Form/Type/ServiceListTypeTest.php
+++ b/tests/Form/Type/ServiceListTypeTest.php
@@ -81,7 +81,7 @@ final class ServiceListTypeTest extends TestCase
             'include_containers' => false,
             'context' => 'cms',
             'choices' => [
-                'my.service.code' => 'value - my.service.code',
+                'value - my.service.code' => 'my.service.code',
             ],
             'empty_data' => '',
             'empty_value' => null,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

It should be safe and BC because this bundle requires Symfony 4 which uses keys as labels and values as values in the choice type field.  `ServiceListType` seems to be used only in [`BlockAdmin`](https://github.com/sonata-project/SonataPageBundle/blob/3.x/src/Admin/BlockAdmin.php#L180).

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #872

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Flipped `ServiceListType` returned `choices` option
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
