### PR TITLE
allow installation with psr/cache version 2&3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.3 || ^8.0",
         "doctrine/collections": "^1.6",
         "doctrine/common": "^2.7.1 || ^3.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "sonata-project/cache": "^2.0",
         "sonata-project/doctrine-extensions": "^1.10.1",
         "sonata-project/form-extensions": "^1.4",


### PR DESCRIPTION
## Subject

psr/cache Version 2 and 3 are only different for implementors but not consumers. allow to install with all versions.
(currently, installation in a fresh symfony 5 skeleton on PHP 8 fails because the block-bundle requires cache version 1 while the skeleton is on version 2.

I am targeting this branch, because it is a non-breaking change.

## Changelog

```markdown
### Added
- Allow installation with psr/cache versions 2 and 3.
```