### PR TITLE
Adapt to interface name

### DIFF
--- a/src/Block/BlockLoaderChain.php
+++ b/src/Block/BlockLoaderChain.php
@@ -51,11 +51,11 @@ class BlockLoaderChain implements BlockLoaderInterface
         return false;
     }
 
-    public function load($block)
+    public function load($name)
     {
         foreach ($this->loaders as $loader) {
-            if ($loader->support($block)) {
-                return $loader->load($block);
+            if ($loader->support($name)) {
+                return $loader->load($name);
             }
         }
 

--- a/src/Block/BlockServiceManager.php
+++ b/src/Block/BlockServiceManager.php
@@ -57,14 +57,14 @@ class BlockServiceManager implements BlockServiceManagerInterface
         return $this->services[$block->getType()];
     }
 
-    public function getService($id)
+    public function getService($name)
     {
-        return $this->load($id);
+        return $this->load($name);
     }
 
-    public function has($id)
+    public function has($name)
     {
-        return isset($this->services[$id]) ? true : false;
+        return isset($this->services[$name]) ? true : false;
     }
 
     public function add($name, $service, $contexts = [])

--- a/src/Block/Loader/ServiceLoader.php
+++ b/src/Block/Loader/ServiceLoader.php
@@ -46,33 +46,33 @@ class ServiceLoader implements BlockLoaderInterface
         return \in_array($type, $this->types, true);
     }
 
-    public function load($configuration)
+    public function load($name)
     {
-        if (!\in_array($configuration['type'], $this->types, true)) {
+        if (!\in_array($name['type'], $this->types, true)) {
             throw new \RuntimeException(sprintf(
                 'The block type "%s" does not exist',
-                $configuration['type']
+                $name['type']
             ));
         }
 
         $block = new Block();
         $block->setId(uniqid('', true));
-        $block->setType($configuration['type']);
+        $block->setType($name['type']);
         $block->setEnabled(true);
         $block->setCreatedAt(new \DateTime());
         $block->setUpdatedAt(new \DateTime());
-        $block->setSettings($configuration['settings'] ?? []);
+        $block->setSettings($name['settings'] ?? []);
 
         return $block;
     }
 
-    public function support($configuration)
+    public function support($name)
     {
-        if (!\is_array($configuration)) {
+        if (!\is_array($name)) {
             return false;
         }
 
-        if (!isset($configuration['type'])) {
+        if (!isset($name['type'])) {
             return false;
         }
 

--- a/src/Menu/MenuRegistry.php
+++ b/src/Menu/MenuRegistry.php
@@ -42,9 +42,9 @@ final class MenuRegistry implements MenuRegistryInterface
         }
     }
 
-    public function add($menu)
+    public function add($name)
     {
-        if ($menu instanceof MenuBuilderInterface) {
+        if ($name instanceof MenuBuilderInterface) {
             @trigger_error(
                 'Adding a '.MenuBuilderInterface::class.' is deprecated since 3.9 and will be removed in 4.0.',
                 \E_USER_DEPRECATED
@@ -53,7 +53,7 @@ final class MenuRegistry implements MenuRegistryInterface
             return;
         }
 
-        $this->names[$menu] = $menu;
+        $this->names[$name] = $name;
     }
 
     public function getAliasNames()

--- a/src/Model/BaseBlock.php
+++ b/src/Model/BaseBlock.php
@@ -160,11 +160,11 @@ abstract class BaseBlock implements BlockInterface
         return $this->updatedAt;
     }
 
-    public function addChildren(BlockInterface $child)
+    public function addChildren(BlockInterface $children)
     {
-        $this->children[] = $child;
+        $this->children[] = $children;
 
-        $child->setParent($this);
+        $children->setParent($this);
     }
 
     public function getChildren()


### PR DESCRIPTION


<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Because of named parameters, the signature of an implementation should
match the one of the interface. I have chose to always use the name in
the interface because that should be a smaller BC-break.

Side-effect: fixing the Psalm job of the CI.

## Changelog



<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix inconsistencies in parameter names between interfaces and their implementations
```
