### PR TITLE
Adapt FormMapper interface to SonataAdmin

### DIFF
--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -6,14 +6,14 @@ UPGRADE FROM 4.x to 4.x
 
 ### Sonata\BlockBundle\Form\Mapper\FormMapper
 
-- Removed the return type of `reorder`, `add`, `remove`.
-- Add the return type of `get`.
-- Add the param typehint of `add`.
-- Removed the method `setHelps` and `addHelp`.
+ - Removed the return type of `reorder`, `add`, `remove`.
+ - Add the return type of `get`.
+ - Add the param typehint of `add`.
+ - Removed the method `setHelps` and `addHelp`.
 
 Those changes are BC-break but
-- some of these are BC for PHP version >= 7.4.
-- others Sonata projects which used this interface didn't have already
+ - some of these are BC for PHP version >= 7.4.
+ - others Sonata projects which used this interface didn't have already
 the support of block-bundle 4.x.
 
 So we'll assume the BC-break as acceptable and this will allow to provide

--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -1,6 +1,28 @@
 UPGRADE 4.x
 ===========
 
+UPGRADE FROM 4.x to 4.x
+=======================
+
+### Sonata\BlockBundle\Form\Mapper\FormMapper
+
+- Removed the return type of `reorder`, `add`, `remove`.
+- Add the return type of `get`.
+- Add the param typehint of `add`.
+- Removed the method `setHelps` and `addHelp`.
+
+Those changes are BC-break but
+- some of these are BC for PHP version >= 7.4.
+- others Sonata projects which used this interface didn't have already
+the support of block-bundle 4.x.
+
+So we'll assume the BC-break as acceptable and this will allow to provide
+a compatibility between classes `Sonata\BlockBundle\Form\Mapper\FormMapper` 4.x
+and `Sonata\AdminBundle\Form\Mapper\FormMapper` 4.x.
+
+UPGRADE FROM 4.4 to 4.5
+=======================
+
 ### Sonata\BlockBundle\Block\BlockContext
 
 Passing a boolean to option "template" is deprecated and will not be allowed in 5.0, pass a `string` or `null` instead.

--- a/src/Form/Mapper/FormMapper.php
+++ b/src/Form/Mapper/FormMapper.php
@@ -14,34 +14,40 @@ declare(strict_types=1);
 namespace Sonata\BlockBundle\Form\Mapper;
 
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * @author Christian Gripp <mail@core23.de>
  */
 interface FormMapper
 {
+    /**
+     * @param class-string<FormTypeInterface>|null $type
+     * @param array<string, mixed>                 $options
+     */
     public function create(string $name, ?string $type = null, array $options = []): FormBuilderInterface;
 
     /**
-     * @param string[] $keys field names
+     * @param string[] $keys
+     *
+     * @return static
      */
-    public function reorder(array $keys): self;
+    public function reorder(array $keys);
 
     /**
-     * @param FormBuilderInterface|string $name
+     * @param class-string<FormTypeInterface>|null $type
+     * @param array<string, mixed>                 $options
+     *
+     * @return static
      */
-    public function add($name, ?string $type = null, array $options = []): self;
+    public function add(string $name, ?string $type = null, array $options = []);
 
-    public function remove(string $key): self;
-
-    public function setHelps(array $helps = []): self;
-
-    public function addHelp(string $name, string $help): self;
+    /**
+     * @return static
+     */
+    public function remove(string $key);
 
     public function has(string $key): bool;
 
-    /**
-     * @return mixed
-     */
-    public function get(string $name);
+    public function get(string $key): FormBuilderInterface;
 }


### PR DESCRIPTION
## Subject

<!-- Describe your Pull Request content here -->

I target this branch to offer compatibility between SonataBlockBundle v4 and SonataAdminBundle v4.

@see https://github.com/sonata-project/SonataAdminBundle/issues/7349

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `Sonata\BlockBundle\Form\Mapper\FormMapper` methods signature to be compatible with `Sonata\AdminBundle\Form\Mapper\FormMapper` 
```