### PR TITLE
Remove Symfony 5.4 deprecations

### DIFF
--- a/docs/reference/cache.rst
+++ b/docs/reference/cache.rst
@@ -55,7 +55,7 @@ or you can use the `Response` object::
             $user = false;
         }
 
-        return Response::create(sprintf("your name is %s", $user->getUsername()))->setTtl(0)->setPrivate();
+        return new Response(sprintf("your name is %s", $user->getUsername()))->setTtl(0)->setPrivate();
     }
 
 Cache Keys
@@ -67,7 +67,7 @@ timestamp. Because these values change on every call from the Twig Helper,
 it is mandatory to overwrite the ``getCacheKeys`` function in your custom block class::
 
     namespace App\Block;
-    
+
     use Sonata\BlockBundle\Block\Service\AbstractBlockService;
     use Sonata\BlockBundle\Block\BlockContextInterface;
     use Sonata\BlockBundle\Model\BlockInterface;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -34,7 +34,7 @@ final class Configuration implements ConfigurationInterface
         $this->defaultContainerTemplates = $defaultContainerTemplates;
     }
 
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sonata_block');
 

--- a/src/DependencyInjection/SonataBlockExtension.php
+++ b/src/DependencyInjection/SonataBlockExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\BlockBundle\DependencyInjection;
 
 use Sonata\BlockBundle\Profiler\DataCollector\BlockDataCollector;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -27,7 +28,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 final class SonataBlockExtension extends Extension
 {
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         $bundles = $container->getParameter('kernel.bundles');
 
@@ -223,7 +224,7 @@ final class SonataBlockExtension extends Extension
         $definition->addMethodCall('setDefaultRenderer', [$defaultRenderer]);
     }
 
-    public function getNamespace()
+    public function getNamespace(): string
     {
         return 'http://sonata-project.com/schema/dic/block';
     }

--- a/src/Form/Type/ContainerTemplateType.php
+++ b/src/Form/Type/ContainerTemplateType.php
@@ -32,12 +32,12 @@ final class ContainerTemplateType extends AbstractType
         $this->templateChoices = $templateChoices;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_type_container_template_choice';
     }
 
-    public function getParent()
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/src/Form/Type/ServiceListType.php
+++ b/src/Form/Type/ServiceListType.php
@@ -29,12 +29,12 @@ final class ServiceListType extends AbstractType
         $this->manager = $manager;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_block_service_choice';
     }
 
-    public function getParent()
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/src/Profiler/DataCollector/BlockDataCollector.php
+++ b/src/Profiler/DataCollector/BlockDataCollector.php
@@ -125,7 +125,7 @@ final class BlockDataCollector extends DataCollector
         return $this->data['realBlocks'];
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'block';
     }

--- a/src/Twig/Extension/BlockExtension.php
+++ b/src/Twig/Extension/BlockExtension.php
@@ -19,7 +19,7 @@ use Twig\TwigFunction;
 
 final class BlockExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(

--- a/src/Util/RecursiveBlockIterator.php
+++ b/src/Util/RecursiveBlockIterator.php
@@ -34,12 +34,12 @@ final class RecursiveBlockIterator extends \RecursiveArrayIterator
         parent::__construct($array);
     }
 
-    public function getChildren()
+    public function getChildren(): self
     {
         return new self($this->current()->getChildren());
     }
 
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return $this->current()->hasChildren();
     }

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
 final class AppKernel extends Kernel
@@ -31,7 +32,7 @@ final class AppKernel extends Kernel
         parent::__construct('test', false);
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [
             new FrameworkBundle(),
@@ -55,9 +56,14 @@ final class AppKernel extends Kernel
         return __DIR__;
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    /**
+     * TODO: Drop RouteCollectionBuilder when support for Symfony < 5.1 is dropped.
+     *
+     * @param RoutingConfigurator|RouteCollectionBuilder $routes
+     */
+    protected function configureRoutes($routes)
     {
-        $routes->import(__DIR__.'/Controller/', '/', 'annotation');
+        $routes->import(__DIR__.'/Controller/');
     }
 
     protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader)

--- a/tests/App/config.yml
+++ b/tests/App/config.yml
@@ -1,5 +1,7 @@
 framework:
     secret: secret
+    router:
+        utf8: true
 
 twig:
     paths:

--- a/tests/Cache/HttpCacheHandlerTest.php
+++ b/tests/Cache/HttpCacheHandlerTest.php
@@ -22,12 +22,12 @@ final class HttpCacheHandlerTest extends TestCase
     public function testComputeTtlWithPrivateResponse(): void
     {
         $handler = new HttpCacheHandler();
-        $handler->updateMetadata(Response::create()->setTtl(60));
-        $handler->updateMetadata(Response::create()->setTtl(55));
-        $handler->updateMetadata(Response::create()->setTtl(42));
-        $handler->updateMetadata(Response::create()->setTtl(55));
+        $handler->updateMetadata((new Response())->setTtl(60));
+        $handler->updateMetadata((new Response())->setTtl(55));
+        $handler->updateMetadata((new Response())->setTtl(42));
+        $handler->updateMetadata((new Response())->setTtl(55));
 
-        $handler->alterResponse($response = Response::create());
+        $handler->alterResponse($response = (new Response()));
 
         static::assertNull($response->getTtl());
     }
@@ -35,12 +35,12 @@ final class HttpCacheHandlerTest extends TestCase
     public function testComputeTtlWithPublicResponse(): void
     {
         $handler = new HttpCacheHandler();
-        $handler->updateMetadata(Response::create()->setTtl(60));
-        $handler->updateMetadata(Response::create()->setTtl(55));
-        $handler->updateMetadata(Response::create()->setTtl(42));
-        $handler->updateMetadata(Response::create()->setTtl(55));
+        $handler->updateMetadata((new Response())->setTtl(60));
+        $handler->updateMetadata((new Response())->setTtl(55));
+        $handler->updateMetadata((new Response())->setTtl(42));
+        $handler->updateMetadata((new Response())->setTtl(55));
 
-        $handler->alterResponse($response = Response::create()->setTtl(84));
+        $handler->alterResponse($response = (new Response())->setTtl(84));
 
         static::assertSame(42, $response->getTtl());
     }
@@ -49,7 +49,7 @@ final class HttpCacheHandlerTest extends TestCase
     {
         $handler = new HttpCacheHandler();
 
-        $handler->alterResponse($response = Response::create()->setTtl(84));
+        $handler->alterResponse($response = (new Response())->setTtl(84));
 
         static::assertSame(84, $response->getTtl());
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because is where sf 5.4 is allowed.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecations triggered using Symfony 5.4
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
