### PR TITLE
Deprecate null template for BlockContext

### DIFF
--- a/src/Block/BlockContext.php
+++ b/src/Block/BlockContext.php
@@ -32,6 +32,26 @@ final class BlockContext implements BlockContextInterface
      */
     public function __construct(BlockInterface $block, array $settings = [])
     {
+        if (!\array_key_exists('template', $settings)) {
+            @trigger_error(
+                'Not providing a "template" setting is deprecated since sonata-project/block-bundle 4.x'
+                .' and will be throw an exception in version 5.0.',
+                \E_USER_DEPRECATED
+            );
+
+        // NEXT_MAJOR: Uncomment the exception instead.
+            // throw new \InvalidArgumentException('The "template" setting is required.');
+        } elseif (!\is_string($settings['template'])) {
+            @trigger_error(
+                'Not providing a string value for the "template" setting is deprecated since'
+                .' sonata-project/block-bundle 4.x and will be throw an exception in version 5.0.',
+                \E_USER_DEPRECATED
+            );
+
+            // NEXT_MAJOR: Uncomment the exception instead.
+            // throw new \InvalidArgumentException('The "template" setting MUST be a string.');
+        }
+
         $this->block = $block;
         $this->settings = $settings;
     }
@@ -66,6 +86,9 @@ final class BlockContext implements BlockContextInterface
         return $this;
     }
 
+    /**
+     * NEXT_MAJOR: Restrict typehint to string.
+     */
     public function getTemplate(): ?string
     {
         return $this->getSetting('template');

--- a/src/Block/BlockContextInterface.php
+++ b/src/Block/BlockContextInterface.php
@@ -34,5 +34,8 @@ interface BlockContextInterface
      */
     public function setSetting(string $name, $value): self;
 
+    /**
+     * NEXT_MAJOR: Restrict typehint to string.
+     */
     public function getTemplate(): ?string;
 }

--- a/src/Block/BlockContextManager.php
+++ b/src/Block/BlockContextManager.php
@@ -118,7 +118,7 @@ final class BlockContextManager implements BlockContextManagerInterface
                 $e->getMessage()
             ));
 
-            $settings = $this->resolve($block, $settings);
+            $settings = $this->resolve($block, $settings + ['template' => $block->getSetting('template')]);
         }
 
         $blockContext = new BlockContext($block, $settings);
@@ -135,7 +135,7 @@ final class BlockContextManager implements BlockContextManagerInterface
             'use_cache' => true,
             'extra_cache_keys' => [],
             'attr' => [],
-            'template' => null,
+            'template' => null, // NEXT_MAJOR: Remove the default value
             'ttl' => $block->getTtl(),
         ]);
 
@@ -144,7 +144,7 @@ final class BlockContextManager implements BlockContextManagerInterface
             ->addAllowedTypes('extra_cache_keys', 'array')
             ->addAllowedTypes('attr', 'array')
             ->addAllowedTypes('ttl', 'int')
-            // NEXT_MAJOR: Remove bool.
+            // NEXT_MAJOR: Remove bool and null.
             ->addAllowedTypes('template', ['null', 'string', 'bool'])
             // NEXT_MAJOR: Remove setDeprecated.
             ->setDeprecated(
@@ -153,7 +153,7 @@ final class BlockContextManager implements BlockContextManagerInterface
                     '4.5.0',
                     static function (Options $options, $value): string {
                         if (\is_bool($value)) {
-                            return 'Passing a boolean to option "template" is deprecated and will not be allowed in 5.0, pass a string or null instead.';
+                            return 'Not passing a string value to option "template" is deprecated and will not be allowed in 5.0.';
                         }
 
                         return '';

--- a/src/Event/BlockEvent.php
+++ b/src/Event/BlockEvent.php
@@ -52,7 +52,7 @@ final class BlockEvent extends Event
     /**
      * @return BlockInterface[]
      */
-    public function getBlocks()
+    public function getBlocks(): array
     {
         return $this->blocks;
     }

--- a/src/Model/BaseBlock.php
+++ b/src/Model/BaseBlock.php
@@ -75,6 +75,7 @@ abstract class BaseBlock implements BlockInterface
         $this->children = [];
     }
 
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         return sprintf('%s ~ #%s', $this->getName(), $this->getId());

--- a/src/Model/BaseBlock.php
+++ b/src/Model/BaseBlock.php
@@ -75,6 +75,11 @@ abstract class BaseBlock implements BlockInterface
         $this->children = [];
     }
 
+    /**
+     * NEXT_MAJOR: Add return typehint.
+     *
+     * @return string
+     */
     #[\ReturnTypeWillChange]
     public function __toString()
     {

--- a/src/Profiler/DataCollector/BlockDataCollector.php
+++ b/src/Profiler/DataCollector/BlockDataCollector.php
@@ -79,10 +79,8 @@ final class BlockDataCollector extends DataCollector
 
     /**
      * Returns the number of block used.
-     *
-     * @return int
      */
-    public function getTotalBlock()
+    public function getTotalBlock(): int
     {
         return \count($this->data['realBlocks']) + \count($this->data['containers']);
     }
@@ -92,7 +90,7 @@ final class BlockDataCollector extends DataCollector
      *
      * @return array<string, mixed>
      */
-    public function getEvents()
+    public function getEvents(): array
     {
         return $this->data['events'];
     }
@@ -102,7 +100,7 @@ final class BlockDataCollector extends DataCollector
      *
      * @return array<string, mixed>
      */
-    public function getBlocks()
+    public function getBlocks(): array
     {
         return $this->data['blocks'];
     }
@@ -112,7 +110,7 @@ final class BlockDataCollector extends DataCollector
      *
      * @return array<string, mixed>
      */
-    public function getContainers()
+    public function getContainers(): array
     {
         return $this->data['containers'];
     }
@@ -122,7 +120,7 @@ final class BlockDataCollector extends DataCollector
      *
      * @return array<string, mixed>
      */
-    public function getRealBlocks()
+    public function getRealBlocks(): array
     {
         return $this->data['realBlocks'];
     }

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -36,7 +36,7 @@ final class GlobalVariables
     /**
      * @return string[]
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         return $this->templates;
     }

--- a/tests/Block/BlockContextManagerTest.php
+++ b/tests/Block/BlockContextManagerTest.php
@@ -41,7 +41,9 @@ final class BlockContextManagerTest extends TestCase
 
         $manager = new BlockContextManager($blockLoader, $serviceManager);
 
-        $blockContext = $manager->get($block);
+        $settings = ['template' => 'custom.html.twig'];
+
+        $blockContext = $manager->get($block, $settings);
 
         static::assertInstanceOf(BlockContextInterface::class, $blockContext);
 
@@ -49,7 +51,7 @@ final class BlockContextManagerTest extends TestCase
             'use_cache' => true,
             'extra_cache_keys' => [],
             'attr' => [],
-            'template' => null,
+            'template' => 'custom.html.twig',
             'ttl' => 0,
         ], $blockContext->getSettings());
     }
@@ -107,8 +109,10 @@ final class BlockContextManagerTest extends TestCase
 
         $block = $this->createMock(BlockInterface::class);
         $block->expects(static::once())->method('getSettings')->willReturn([
-            'template' => [],
+            'template' => 'custom.html.twig',
+            'attr' => 'shouldBeAnArray',
         ]);
+        $block->expects(static::once())->method('getSetting')->with('template')->willReturn('custom.html.twig');
 
         $manager = new BlockContextManager($blockLoader, $serviceManager, [], $logger);
 

--- a/tests/Block/BlockExecutionContextTest.php
+++ b/tests/Block/BlockExecutionContextTest.php
@@ -25,10 +25,15 @@ final class BlockExecutionContextTest extends TestCase
 
         $blockContext = new BlockContext($block, [
             'hello' => 'world',
+            'template' => 'fake_template',
         ]);
 
         static::assertSame('world', $blockContext->getSetting('hello'));
-        static::assertSame(['hello' => 'world'], $blockContext->getSettings());
+        static::assertSame('fake_template', $blockContext->getTemplate());
+        static::assertSame([
+            'hello' => 'world',
+            'template' => 'fake_template',
+        ], $blockContext->getSettings());
 
         static::assertSame($block, $blockContext->getBlock());
     }
@@ -39,7 +44,9 @@ final class BlockExecutionContextTest extends TestCase
 
         $block = $this->createMock(BlockInterface::class);
 
-        $blockContext = new BlockContext($block);
+        $blockContext = new BlockContext($block, [
+            'template' => 'fake_template',
+        ]);
 
         $blockContext->getSetting('fake');
     }

--- a/tests/Block/BlockRendererTest.php
+++ b/tests/Block/BlockRendererTest.php
@@ -75,7 +75,9 @@ final class BlockRendererTest extends TestCase
 
         // mock a block object
         $block = $this->createMock(BlockInterface::class);
-        $blockContext = new BlockContext($block);
+        $blockContext = new BlockContext($block, [
+            'template' => 'fake_template',
+        ]);
 
         $result = $this->renderer->render($blockContext);
 
@@ -112,7 +114,9 @@ final class BlockRendererTest extends TestCase
 
         // mock a block object
         $block = $this->createMock(BlockInterface::class);
-        $blockContext = new BlockContext($block);
+        $blockContext = new BlockContext($block, [
+            'template' => 'fake_template',
+        ]);
 
         $result = $this->renderer->render($blockContext);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #855.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Not passing a string value for the template setting of a BlockContext
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
