### PR TITLE
fix phpstan/psalm errors

### DIFF
--- a/src/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -29,9 +29,13 @@ final class TweakCompilerPass implements CompilerPassInterface
         $manager = $container->getDefinition('sonata.block.manager');
         $registry = $container->getDefinition('sonata.block.menu.registry');
 
+        /** @var array<string, mixed> $blocks */
         $blocks = $container->getParameter('sonata_block.blocks');
+        /** @var array<string, mixed> $blockTypes */
         $blockTypes = $container->getParameter('sonata_blocks.block_types');
+        /** @var array<string, mixed> $cacheBlocks */
         $cacheBlocks = $container->getParameter('sonata_block.cache_blocks');
+        /** @var string[] $defaultContexs */
         $defaultContexs = $container->getParameter('sonata_blocks.default_contexts');
 
         foreach ($container->findTaggedServiceIds('sonata.block') as $id => $tags) {

--- a/src/DependencyInjection/SonataBlockExtension.php
+++ b/src/DependencyInjection/SonataBlockExtension.php
@@ -33,6 +33,7 @@ final class SonataBlockExtension extends Extension
      */
     public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
+        /** @var array<string, mixed> $bundles */
         $bundles = $container->getParameter('kernel.bundles');
 
         $defaultTemplates = [];
@@ -51,6 +52,7 @@ final class SonataBlockExtension extends Extension
 
     public function load(array $configs, ContainerBuilder $container): void
     {
+        /** @var array<string, mixed> $bundles */
         $bundles = $container->getParameter('kernel.bundles');
 
         $processor = new Processor();

--- a/src/Form/Type/ServiceListType.php
+++ b/src/Form/Type/ServiceListType.php
@@ -67,16 +67,16 @@ final class ServiceListType extends AbstractType
             },
             'preferred_choices' => [],
             'empty_data' => static function (Options $options) {
-                $multiple = isset($options['multiple']) && $options['multiple'];
-                $expanded = isset($options['expanded']) && $options['expanded'];
+                $multiple = $options['multiple'] ?? false;
+                $expanded = $options['expanded'] ?? false;
 
-                return $multiple || $expanded ? [] : '';
+                return true === $multiple || true === $expanded ? [] : '';
             },
             'empty_value' => static function (Options $options, $previousValue): ?string {
-                $multiple = isset($options['multiple']) && $options['multiple'];
-                $expanded = isset($options['expanded']) && $options['expanded'];
+                $multiple = $options['multiple'] ?? false;
+                $expanded = $options['expanded'] ?? false;
 
-                return $multiple || $expanded || !isset($previousValue) ? null : '';
+                return true === $multiple || true === $expanded || !isset($previousValue) ? null : '';
             },
             'error_bubbling' => false,
             'include_containers' => false,


### PR DESCRIPTION
```
 ------ ----------------------------------------------------------------- 
  Line   src/Form/Type/ServiceListType.php                                
 ------ ----------------------------------------------------------------- 
  70     Only booleans are allowed in &&, mixed given on the right side.  
  71     Only booleans are allowed in &&, mixed given on the right side.  
  76     Only booleans are allowed in &&, mixed given on the right side.  
  77     Only booleans are allowed in &&, mixed given on the right side.  
 ------ ----------------------------------------------------------------- 
```

```
Error: src/DependencyInjection/Compiler/TweakCompilerPass.php:45:17: UndefinedInterfaceMethod: Method UnitEnum::offsetSet does not exist (see https://psalm.dev/181)
Error: src/DependencyInjection/Compiler/TweakCompilerPass.php:48:17: UndefinedInterfaceMethod: Method UnitEnum::offsetSet does not exist (see https://psalm.dev/181)
Error: src/DependencyInjection/Compiler/TweakCompilerPass.php:50:23: UndefinedInterfaceMethod: Method UnitEnum::offsetGet does not exist (see https://psalm.dev/181)
Error: src/DependencyInjection/SonataBlockExtension.php:39:19: UndefinedInterfaceMethod: Method UnitEnum::offsetGet does not exist (see https://psalm.dev/181)
Error: src/DependencyInjection/SonataBlockExtension.php:45:19: UndefinedInterfaceMethod: Method UnitEnum::offsetGet does not exist (see https://psalm.dev/181)
Error: src/DependencyInjection/SonataBlockExtension.php:63:19: UndefinedInterfaceMethod: Method UnitEnum::offsetGet does not exist (see https://psalm.dev/181)
Error: src/DependencyInjection/SonataBlockExtension.php:81:23: UndefinedInterfaceMethod: Method UnitEnum::offsetGet does not exist (see https://psalm.dev/181)
```