### PR TITLE
Allow blockContext without template

### DIFF
--- a/src/Block/BlockContext.php
+++ b/src/Block/BlockContext.php
@@ -32,26 +32,6 @@ final class BlockContext implements BlockContextInterface
      */
     public function __construct(BlockInterface $block, array $settings = [])
     {
-        if (!\array_key_exists('template', $settings)) {
-            @trigger_error(
-                'Not providing a "template" setting is deprecated since sonata-project/block-bundle 4.10'
-                .' and will be throw an exception in version 5.0.',
-                \E_USER_DEPRECATED
-            );
-
-        // NEXT_MAJOR: Uncomment the exception instead.
-            // throw new \InvalidArgumentException('The "template" setting is required.');
-        } elseif (!\is_string($settings['template'])) {
-            @trigger_error(
-                'Not providing a string value for the "template" setting is deprecated since'
-                .' sonata-project/block-bundle 4.10 and will be throw an exception in version 5.0.',
-                \E_USER_DEPRECATED
-            );
-
-            // NEXT_MAJOR: Uncomment the exception instead.
-            // throw new \InvalidArgumentException('The "template" setting MUST be a string.');
-        }
-
         $this->block = $block;
         $this->settings = $settings;
     }
@@ -91,6 +71,19 @@ final class BlockContext implements BlockContextInterface
      */
     public function getTemplate(): ?string
     {
-        return $this->getSetting('template');
+        $template = $this->getSetting('template');
+
+        if (!\is_string($template)) {
+            @trigger_error(
+                'Not providing a string value for the "template" setting is deprecated since'
+                .' sonata-project/block-bundle 4.10 and will be throw an exception in version 5.0.',
+                \E_USER_DEPRECATED
+            );
+
+            // NEXT_MAJOR: Uncomment the exception instead.
+            // throw new \InvalidArgumentException('The "template" setting MUST be a string.');
+        }
+
+        return $template;
     }
 }

--- a/src/Block/BlockContextManager.php
+++ b/src/Block/BlockContextManager.php
@@ -118,6 +118,7 @@ final class BlockContextManager implements BlockContextManagerInterface
                 $e->getMessage()
             ));
 
+            // NEXT_MAJOR: Only pass the template value if it's a string.
             $settings = $this->resolve($block, $settings + ['template' => $block->getSetting('template')]);
         }
 


### PR DESCRIPTION
## Subject

SonataAdmin is using BlockContext without template. The template is provided instead by the admin.
I think it's fine to not provide a template then. But we should have the deprecation for null template in the getter then.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Do not trigger a deprecation if a template setting is not provided in a block context `__construct`.
```