### PR TITLE
deprecate more caching related things within BlockContextManager

### DIFF
--- a/src/Block/BlockContextManager.php
+++ b/src/Block/BlockContextManager.php
@@ -45,9 +45,11 @@ final class BlockContextManager implements BlockContextManagerInterface
     private $settingsByClass = [];
 
     /**
+     * NEXT_MAJOR: remove.
+     *
      * @var array{by_class: array<class-string, string>, by_type: array<string, string>}
      */
-    private $cacheBlocks;
+    private $cacheBlocks = ['by_class' => [], 'by_type' => []];
 
     /**
      * @var LoggerInterface
@@ -55,18 +57,52 @@ final class BlockContextManager implements BlockContextManagerInterface
     private $logger;
 
     /**
-     * @param array{by_class: array<class-string, string>, by_type: array<string, string>} $cacheBlocks
+     * NEXT_MAJOR: remove $cacheBlocksOrLogger argument.
+     *
+     * @param array{by_class: array<class-string, string>, by_type: array<string, string>}|LoggerInterface|null $cacheBlocksOrLogger
      */
     public function __construct(
         BlockLoaderInterface $blockLoader,
         BlockServiceManagerInterface $blockService,
-        array $cacheBlocks = ['by_class' => [], 'by_type' => []],
+        $cacheBlocksOrLogger = null,
         ?LoggerInterface $logger = null
     ) {
         $this->blockLoader = $blockLoader;
         $this->blockService = $blockService;
-        $this->cacheBlocks = $cacheBlocks;
-        $this->logger = $logger ?? new NullLogger();
+
+        // NEXT_MAJOR: remove if/else block completely and uncomment following line
+        // $this->logger = $logger ?? new NullLogger();
+        if (\is_array($cacheBlocksOrLogger)) {
+            $this->cacheBlocks = $cacheBlocksOrLogger;
+            @trigger_error(
+                sprintf(
+                    'Passing an array as argument 3 for method "%s" is deprecated since sonata-project/block-bundle 4.x. The argument will change to "?%s" in 5.0.',
+                    __METHOD__,
+                    LoggerInterface::class
+                ),
+                \E_USER_DEPRECATED
+            );
+            $this->logger = new NullLogger();
+        } elseif ($cacheBlocksOrLogger instanceof LoggerInterface) {
+            $this->logger = $cacheBlocksOrLogger;
+        } elseif (null === $cacheBlocksOrLogger) {
+            $this->logger = new NullLogger();
+        } else {
+            throw new \TypeError('Argument 3 must be null|array|LoggerInterface');
+        }
+
+        // NEXT_MAJOR: remove
+        if (null !== $logger) {
+            $this->logger = $logger;
+            @trigger_error(
+                sprintf(
+                    'Passing an instance of "%s" as argument 4 to method "%s" is deprecated since sonata-project/block-bundle 4.x. The argument will be removed in 5.0.',
+                    LoggerInterface::class,
+                    __METHOD__
+                ),
+                \E_USER_DEPRECATED
+            );
+        }
     }
 
     public function addSettingsByType(string $type, array $settings, bool $replace = false): void

--- a/src/Block/BlockContextManagerInterface.php
+++ b/src/Block/BlockContextManagerInterface.php
@@ -18,6 +18,11 @@ use Sonata\BlockBundle\Model\BlockInterface;
 
 interface BlockContextManagerInterface
 {
+    /**
+     * NEXT_MAJOR: remove.
+     *
+     * @deprecated
+     */
     public const CACHE_KEY = 'context';
 
     /**

--- a/src/DependencyInjection/Compiler/BlockHelperCompilerPass.php
+++ b/src/DependencyInjection/Compiler/BlockHelperCompilerPass.php
@@ -58,5 +58,13 @@ final class BlockHelperCompilerPass implements CompilerPassInterface
             new Reference('sonata.block.cache.handler', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             new Reference('debug.stopwatch', ContainerInterface::NULL_ON_INVALID_REFERENCE),
         ]);
+
+        $blockContextManagerDefinition = $container->getDefinition('sonata.block.context_manager.default');
+        $blockContextManagerDefinition->setArguments([
+            new Reference('sonata.block.loader.chain'),
+            new Reference('sonata.block.manager'),
+            new Parameter('sonata_block.cache_blocks'),
+            new Reference('logger', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+        ]);
     }
 }

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -46,7 +46,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             new ReferenceConfigurator('sonata.block.loader.chain'),
             new ReferenceConfigurator('sonata.block.manager'),
-            '%sonata_block.cache_blocks%',
             (new ReferenceConfigurator('logger'))->nullOnInvalid(),
         ]);
 

--- a/tests/Block/BlockContextManagerTest.php
+++ b/tests/Block/BlockContextManagerTest.php
@@ -48,10 +48,13 @@ final class BlockContextManagerTest extends TestCase
         static::assertInstanceOf(BlockContextInterface::class, $blockContext);
 
         static::assertSame([
+            // NEXT_MAJOR: remove
             'use_cache' => true,
+            // NEXT_MAJOR: remove
             'extra_cache_keys' => [],
             'attr' => [],
             'template' => 'custom.html.twig',
+            // NEXT_MAJOR: remove
             'ttl' => 0,
         ], $blockContext->getSettings());
     }
@@ -74,6 +77,7 @@ final class BlockContextManagerTest extends TestCase
         $block = $this->createMock(BlockInterface::class);
         $block->expects(static::once())->method('getSettings')->willReturn([]);
 
+        // NEXT_MAJOR: remove
         $blocksCache = [
             'by_class' => [ClassUtils::getClass($block) => 'my_cache.service.id'],
             'by_type' => [],
@@ -89,7 +93,9 @@ final class BlockContextManagerTest extends TestCase
         static::assertInstanceOf(BlockContextInterface::class, $blockContext);
 
         static::assertSame([
+            // NEXT_MAJOR: remove
             'use_cache' => true,
+            // NEXT_MAJOR: remove
             'extra_cache_keys' => [
                 BlockContextManager::CACHE_KEY => [
                     'template' => 'custom.html.twig',
@@ -122,8 +128,7 @@ final class BlockContextManagerTest extends TestCase
         ]);
         $block->expects(static::once())->method('getSetting')->with('template')->willReturn('custom.html.twig');
 
-        $cacheBlock = ['by_class' => [], 'by_type' => []];
-        $manager = new BlockContextManager($blockLoader, $serviceManager, $cacheBlock, $logger);
+        $manager = new BlockContextManager($blockLoader, $serviceManager, $logger);
 
         $blockContext = $manager->get($block);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Deprecate `$cacheBlocks` argument on `BlockContextManager::__construct`. 

I overlooked this in https://github.com/sonata-project/SonataBlockBundle/pull/1011.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- deprecated passing array `$cacheBlocks` as 3rd argument for `BlockContextManager::__construct`
- deprecated `BlockContextManagerInterface::CACHE_KEY`

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
