### PR TITLE
more missing deprecations for caching functionality

### DIFF
--- a/src/Block/Service/AbstractBlockService.php
+++ b/src/Block/Service/AbstractBlockService.php
@@ -52,10 +52,22 @@ abstract class AbstractBlockService implements BlockServiceInterface
      * Returns a Response object that cannot be cacheable, this must be used if the Response is related to the user.
      * A good solution to make the page cacheable is to configure the block to be cached with javascript ...
      *
+     * @deprecated since sonata-project/block-bundle 4.x and will be removed in 5.0.
+     *
+     * NEXT_MAJOR: remove
+     *
      * @param array<string, mixed> $parameters
      */
     public function renderPrivateResponse(string $view, array $parameters = [], ?Response $response = null): Response
     {
+        @trigger_error(
+            sprintf(
+                'Method "%s" is deprecated since sonata-project/block-bundle 4.x and will be removed in 5.0.',
+                __METHOD__
+            ),
+            \E_USER_DEPRECATED
+        );
+
         return $this->renderResponse($view, $parameters, $response)
             ->setTtl(0)
             ->setPrivate();

--- a/src/Block/Service/MenuBlockService.php
+++ b/src/Block/Service/MenuBlockService.php
@@ -69,6 +69,7 @@ class MenuBlockService extends AbstractBlockService implements EditableBlockServ
             'context' => $blockContext,
         ];
 
+        // NEXT_MAJOR: remove
         if ('private' === $blockContext->getSetting('cache_policy')) {
             return $this->renderPrivateResponse($template, $responseSettings, $response);
         }
@@ -104,6 +105,7 @@ class MenuBlockService extends AbstractBlockService implements EditableBlockServ
     {
         $resolver->setDefaults([
             'title' => '',
+            // NEXT_MAJOR: Remove.
             'cache_policy' => 'public',
             'template' => '@SonataBlock/Block/block_core_menu.html.twig',
             'menu_name' => '',
@@ -116,6 +118,15 @@ class MenuBlockService extends AbstractBlockService implements EditableBlockServ
             'children_class' => 'list-group-item',
             'menu_template' => null,
         ]);
+
+        // NEXT_MAJOR: Remove setDeprecated.
+        $resolver->setDeprecated(
+            'cache_policy',
+            ...$this->deprecationParameters(
+                '4.x',
+                'Option "cache_policy" is deprecated since sonata-project/block-bundle 4.x and will be removed in 5.0.'
+            )
+        );
     }
 
     public function getMetadata(): MetadataInterface
@@ -217,5 +228,27 @@ class MenuBlockService extends AbstractBlockService implements EditableBlockServ
         }
 
         return $options;
+    }
+
+    /**
+     * This class is a BC layer for deprecation messages for symfony/options-resolver < 5.1.
+     * Remove this class when dropping support for symfony/options-resolver < 5.1.
+     *
+     * @param string|\Closure $message
+     *
+     * @return mixed[]
+     */
+    private function deprecationParameters(string $version, $message): array
+    {
+        // @phpstan-ignore-next-line
+        if (method_exists(OptionsResolver::class, 'define')) {
+            return [
+                'sonata-project/block-bundle',
+                $version,
+                $message,
+            ];
+        }
+
+        return [$message];
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

See https://github.com/sonata-project/SonataBlockBundle/pull/1044#discussion_r856877867

Needed for removal on 5.x.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- deprecated method `AbstractBlockService::renderPrivateResponse()` 
- deprecated option `cache_policy` on `MenuBlockService`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
