### PR TITLE
fix BlockHelper service definition

### DIFF
--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -70,8 +70,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             new ReferenceConfigurator('sonata.block.context_manager'),
             new ReferenceConfigurator('event_dispatcher'),
             (new ReferenceConfigurator('debug.stopwatch'))->nullOnInvalid(),
-            (new ReferenceConfigurator('sonata.cache.manager'))->nullOnInvalid(),
-            (new ReferenceConfigurator('sonata.block.cache.handler'))->nullOnInvalid(),
         ]);
 
     $services->set('sonata.block.loader.chain', BlockLoaderChain::class)


### PR DESCRIPTION
While looking into making SonataAdmin compatible with latest changes here I noticed that the service definition for `BlockHelper` does not work properly:

```
1) Sonata\AdminBundle\Tests\Functional\Controller\CRUDControllerTest::testList
TypeError: Sonata\BlockBundle\Templating\Helper\BlockHelper::__construct(): Argument #6 ($cacheManager) must be of type ?Sonata\Cache\CacheManagerInterface, Sonata\BlockBundle\Cache\HttpCacheHandler given, called in /tmp/sonata-admin-bundle/var/cache/ContainerEpj339p/getSonata_Block_Templating_HelperService.php on line 20

/var/www/SonataAdminBundle/vendor/sonata-project/block-bundle/src/Templating/Helper/BlockHelper.php:129
/var/www/SonataAdminBundle/vendor/symfony/form/Extension/DependencyInjection/DependencyInjectionExtension.php:67
/var/www/SonataAdminBundle/vendor/symfony/form/FormRegistry.php:108
/var/www/SonataAdminBundle/vendor/symfony/form/FormRegistry.php:84
/var/www/SonataAdminBundle/vendor/symfony/form/FormFactory.php:67
/var/www/SonataAdminBundle/tests/App/Builder/DatagridBuilder.php:68
/var/www/SonataAdminBundle/src/Admin/AbstractAdmin.php:2377
/var/www/SonataAdminBundle/src/Admin/AbstractAdmin.php:956
/var/www/SonataAdminBundle/src/Controller/CRUDController.php:121
/var/www/SonataAdminBundle/vendor/symfony/http-kernel/HttpKernel.php:152
/var/www/SonataAdminBundle/vendor/symfony/http-kernel/HttpKernel.php:74
/var/www/SonataAdminBundle/vendor/symfony/http-kernel/Kernel.php:202
/var/www/SonataAdminBundle/vendor/symfony/http-kernel/HttpKernelBrowser.php:65
/var/www/SonataAdminBundle/vendor/symfony/framework-bundle/KernelBrowser.php:172
/var/www/SonataAdminBundle/vendor/symfony/browser-kit/AbstractBrowser.php:370
/var/www/SonataAdminBundle/tests/Functional/Controller/CRUDControllerTest.php:26
```

The default definition should be the new signature without any deprecations.

In case caching is used it will be changed [here](https://github.com/sonata-project/SonataBlockBundle/blob/4.x/src/DependencyInjection/Compiler/BlockHelperCompilerPass.php#L51) anyway.

This is currently not covered with tests as the functional tests use `http_cache: false` and disable caching completely anyway.

Caused by https://github.com/sonata-project/SonataBlockBundle/commit/3d589d6bd26f9cab6bd26c2bbea60c04dcaad18a#diff-97b3cbefcb17afe6a4336f0f1be39c328d308b6443dd80eb95c9a7739c0da2ffL69. So this is not released yet luckily.