### PR TITLE
use service locator within BlockServiceManager

### DIFF
--- a/src/Block/BlockServiceManagerInterface.php
+++ b/src/Block/BlockServiceManagerInterface.php
@@ -31,12 +31,12 @@ interface BlockServiceManagerInterface
     public function get(BlockInterface $block): BlockServiceInterface;
 
     /**
-     * @return BlockServiceInterface[]
+     * @return array<string, BlockServiceInterface>
      */
     public function getServices(): array;
 
     /**
-     * @return BlockServiceInterface[]
+     * @return array<string, BlockServiceInterface>
      */
     public function getServicesByContext(string $context, bool $includeContainers = true): array;
 

--- a/src/DependencyInjection/Compiler/TweakCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TweakCompilerPass.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\BlockBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -38,7 +39,10 @@ final class TweakCompilerPass implements CompilerPassInterface
         /** @var string[] $defaultContexts */
         $defaultContexts = $container->getParameter('sonata_blocks.default_contexts');
 
+        /** @var array<string, Reference> $blockServiceReferences */
+        $blockServiceReferences = [];
         foreach ($container->findTaggedServiceIds('sonata.block') as $id => $tags) {
+            // NEXT_MAJOR: remove and do not make them public
             $container->getDefinition($id)
                 ->setPublic(true);
 
@@ -56,7 +60,11 @@ final class TweakCompilerPass implements CompilerPassInterface
             }
 
             $manager->addMethodCall('add', [$id, $id, $settings['contexts']]);
+
+            $blockServiceReferences[$id] = new Reference($id);
         }
+
+        $manager->setArgument(0, ServiceLocatorTagPass::register($container, $blockServiceReferences));
 
         foreach ($container->findTaggedServiceIds('knp_menu.menu') as $serviceId => $tags) {
             foreach ($tags as $attributes) {

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -33,9 +33,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set('sonata.block.manager', BlockServiceManager::class)
         ->public()
         ->args([
-            new ReferenceConfigurator('service_container'),
-            '%kernel.debug%',
-            (new ReferenceConfigurator('logger'))->nullOnInvalid(),
+            null, // replaced in compiler pass
+            '%sonata.block.container.types%',
         ]);
 
     $services->set('sonata.block.menu.registry', MenuRegistry::class)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataBlockBundle/issues/876

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- block services are now accessed via service locator within `BlockServiceManager` 
### Deprecated
- deprecated not passing container types as second argument to `BlockServiceManager::__construct` 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
