### PR TITLE
Deprecate FormMapper::create

### DIFF
--- a/src/Form/Mapper/FormMapper.php
+++ b/src/Form/Mapper/FormMapper.php
@@ -22,6 +22,10 @@ use Symfony\Component\Form\FormTypeInterface;
 interface FormMapper
 {
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/block-bundle 4.x. To be removed in 5.0.
+     *
      * @param class-string<FormTypeInterface>|null $type
      * @param array<string, mixed>                 $options
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

See https://github.com/sonata-project/SonataAdminBundle/pull/7265#issuecomment-1125092684

The only usage found is https://github.com/sonata-project/SonataClassificationBundle/blob/4.x/src/Block/Service/AbstractClassificationBlockService.php#L68

This can be replaced by the implementation
```
$formBuilder->create(...);
```

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- FormMapper::create() method.
```