### PR TITLE
Avoid hasChildren deprecation

### DIFF
--- a/src/Model/BaseBlock.php
+++ b/src/Model/BaseBlock.php
@@ -199,7 +199,7 @@ abstract class BaseBlock implements BlockInterface
         $children->setParent($this);
     }
 
-    public function getChildren(): iterable
+    public function getChildren()
     {
         return $this->children;
     }

--- a/src/Model/BlockInterface.php
+++ b/src/Model/BlockInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\BlockBundle\Model;
 
+use Doctrine\Common\Collections\Collection;
+
 /**
  * @method void addChild(self $child)
  * @method bool hasChild()
@@ -92,9 +94,9 @@ interface BlockInterface
     /**
      * NEXT_MAJOR: Restrict typehint to Collection.
      *
-     * @return iterable<BlockInterface> $children
+     * @return Collection<int, BlockInterface>|array<BlockInterface> $children
      */
-    public function getChildren(): iterable;
+    public function getChildren();
 
     /**
      * NEXT_MAJOR: Rename hasChild().

--- a/src/Util/RecursiveBlockIterator.php
+++ b/src/Util/RecursiveBlockIterator.php
@@ -14,20 +14,17 @@ declare(strict_types=1);
 namespace Sonata\BlockBundle\Util;
 
 use Doctrine\Common\Collections\Collection;
+use Sonata\BlockBundle\Model\BlockInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
- * @phpstan-template TKey of array-key
- * @phpstan-template T
- * @phpstan-extends \RecursiveArrayIterator<TKey, T>
+ * @phpstan-extends \RecursiveArrayIterator<array-key, BlockInterface>
  */
 final class RecursiveBlockIterator extends \RecursiveArrayIterator
 {
     /**
-     * @param Collection<array-key, mixed>|array<mixed> $array
-     *
-     * @phpstan-param Collection<TKey, T>|array<TKey, T> $array
+     * @param Collection<array-key, BlockInterface>|array<BlockInterface> $array
      */
     public function __construct($array)
     {
@@ -39,7 +36,7 @@ final class RecursiveBlockIterator extends \RecursiveArrayIterator
     }
 
     /**
-     * @phpstan-return RecursiveBlockIterator<TKey, T>
+     * @phpstan-return RecursiveBlockIterator
      */
     public function getChildren(): self
     {
@@ -48,6 +45,6 @@ final class RecursiveBlockIterator extends \RecursiveArrayIterator
 
     public function hasChildren(): bool
     {
-        return $this->current()->hasChildren();
+        return $this->current()->hasChild();
     }
 }

--- a/tests/Util/RecursiveBlockIteratorIteratorTest.php
+++ b/tests/Util/RecursiveBlockIteratorIteratorTest.php
@@ -14,32 +14,20 @@ declare(strict_types=1);
 namespace Sonata\BlockBundle\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
-use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Util\RecursiveBlockIteratorIterator;
 
 final class RecursiveBlockIteratorIteratorTest extends TestCase
 {
     public function testInterface(): void
     {
-        $block2 = $this->createMock(BlockInterface::class);
-        $block2->expects(static::any())->method('getType')->willReturn('block2');
-        $block2->expects(static::once())->method('hasChildren')->willReturn(false);
+        $block1 = new Block();
+        $block2 = new Block();
+        $block3 = new Block();
+        $block4 = new Block();
 
-        $block3 = $this->createMock(BlockInterface::class);
-        $block3->expects(static::any())->method('getType')->willReturn('block3');
-        $block3->expects(static::once())->method('hasChildren')->willReturn(false);
-
-        $block1 = $this->createMock(BlockInterface::class);
-        $block1->expects(static::any())->method('getType')->willReturn('block1');
-        $block1->expects(static::once())->method('hasChildren')->willReturn(true);
-        $block1->expects(static::any())->method('getChildren')->willReturn([
-            $block2,
-            $block3,
-        ]);
-
-        $block4 = $this->createMock(BlockInterface::class);
-        $block4->expects(static::any())->method('getType')->willReturn('block4');
-        $block4->expects(static::any())->method('hasChildren')->willReturn(false);
+        $block1->addChild($block2);
+        $block1->addChild($block3);
 
         $i = new RecursiveBlockIteratorIterator([$block1, $block4]);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Avoid deprecation for the `hasChildren` method.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
