### PR TITLE
Remove editable from ContainerBlockService

### DIFF
--- a/src/Block/Service/ContainerBlockService.php
+++ b/src/Block/Service/ContainerBlockService.php
@@ -41,8 +41,6 @@ final class ContainerBlockService extends AbstractBlockService implements Editab
 
     public function configureEditForm(FormMapper $form, BlockInterface $block): void
     {
-        $form->add('enabled');
-
         $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['code', TextType::class, [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is bug fixing.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Helps with: https://github.com/sonata-project/SonataPageBundle/pull/1552#pullrequestreview-1070687221

The enabled field is already here: 
https://github.com/sonata-project/SonataPageBundle/blob/3.x/src/Admin/BlockAdmin.php#L160-L164
https://github.com/sonata-project/SonataPageBundle/blob/3.x/src/Admin/SharedBlockAdmin.php#L81

So it not needs to be added on each block, This was the only one defining this field.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove `editable` field from `ContainerBlockService`, it was added twice.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
