### PR TITLE
Split EditableBlockService interface

### DIFF
--- a/src/Block/Service/ContainerBlockService.php
+++ b/src/Block/Service/ContainerBlockService.php
@@ -32,7 +32,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-final class ContainerBlockService extends AbstractBlockService implements EditableBlockService
+final class ContainerBlockService extends AbstractBlockService implements MetadataAwareBlockServiceInterface, EditableBlockService
 {
     public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {

--- a/src/Block/Service/EditableBlockService.php
+++ b/src/Block/Service/EditableBlockService.php
@@ -14,20 +14,19 @@ declare(strict_types=1);
 namespace Sonata\BlockBundle\Block\Service;
 
 use Sonata\BlockBundle\Form\Mapper\FormMapper;
-use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Validator\ErrorElement;
 
 /**
+ * NEXT_MAJOR: Extends BlockServiceInterface instead.
+ *
  * @author Christian Gripp <mail@core23.de>
  */
-interface EditableBlockService
+interface EditableBlockService extends MetadataAwareBlockServiceInterface
 {
     public function configureEditForm(FormMapper $form, BlockInterface $block): void;
 
     public function configureCreateForm(FormMapper $form, BlockInterface $block): void;
 
     public function validate(ErrorElement $errorElement, BlockInterface $block): void;
-
-    public function getMetadata(): MetadataInterface;
 }

--- a/src/Block/Service/MenuBlockService.php
+++ b/src/Block/Service/MenuBlockService.php
@@ -34,7 +34,7 @@ use Twig\Environment;
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class MenuBlockService extends AbstractBlockService implements EditableBlockService
+class MenuBlockService extends AbstractBlockService implements MetadataAwareBlockServiceInterface, EditableBlockService
 {
     private MenuProviderInterface $menuProvider;
 

--- a/src/Block/Service/MetadataAwareBlockServiceInterface.php
+++ b/src/Block/Service/MetadataAwareBlockServiceInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\BlockBundle\Block\Service;
+
+use Sonata\BlockBundle\Meta\MetadataInterface;
+
+/**
+ * NEXT_MAJOR: Extends BlockServiceInterface.
+ */
+interface MetadataAwareBlockServiceInterface
+{
+    public function getMetadata(): MetadataInterface;
+}

--- a/src/Block/Service/RssBlockService.php
+++ b/src/Block/Service/RssBlockService.php
@@ -31,7 +31,7 @@ use Symfony\Component\Validator\Constraints\NotNull;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-final class RssBlockService extends AbstractBlockService implements EditableBlockService
+final class RssBlockService extends AbstractBlockService implements MetadataAwareBlockServiceInterface, EditableBlockService
 {
     public function configureSettings(OptionsResolver $resolver): void
     {

--- a/src/Block/Service/TemplateBlockService.php
+++ b/src/Block/Service/TemplateBlockService.php
@@ -26,7 +26,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-final class TemplateBlockService extends AbstractBlockService implements EditableBlockService
+final class TemplateBlockService extends AbstractBlockService implements MetadataAwareBlockServiceInterface, EditableBlockService
 {
     public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
     {

--- a/src/Block/Service/TextBlockService.php
+++ b/src/Block/Service/TextBlockService.php
@@ -27,7 +27,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-final class TextBlockService extends AbstractBlockService implements EditableBlockService
+final class TextBlockService extends AbstractBlockService implements MetadataAwareBlockServiceInterface, EditableBlockService
 {
     public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
     {

--- a/src/Command/DebugBlocksCommand.php
+++ b/src/Command/DebugBlocksCommand.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\BlockBundle\Command;
 
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
-use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Block\Service\MetadataAwareBlockServiceInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -62,7 +62,7 @@ final class DebugBlocksCommand extends Command
             $output->writeln('');
 
             $title = '';
-            if ($service instanceof EditableBlockService) {
+            if ($service instanceof MetadataAwareBlockServiceInterface) {
                 $title = sprintf(' (<comment>%s</comment>)', $service->getMetadata()->getTitle());
             }
             $output->writeln(sprintf('<info>>> %s</info>%s', $code, $title));

--- a/src/Form/Type/ServiceListType.php
+++ b/src/Form/Type/ServiceListType.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\BlockBundle\Form\Type;
 
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
-use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Block\Service\MetadataAwareBlockServiceInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
@@ -53,7 +53,7 @@ final class ServiceListType extends AbstractType
             'choices' => static function (Options $options, $previousValue) use ($manager): array {
                 $types = [];
                 foreach ($manager->getServicesByContext($options['context'], $options['include_containers']) as $code => $service) {
-                    if ($service instanceof EditableBlockService) {
+                    if ($service instanceof MetadataAwareBlockServiceInterface) {
                         $types[sprintf('%s - %s', $service->getMetadata()->getTitle(), $code)] = $code;
                     } else {
                         $types[sprintf('%s', $code)] = $code;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I might be wrong but the `getMetadata` seems to be only used in PageBundle, and I'm not sure if it should really be related to the EditableBlockServiceInterface. IMHO you can edit something without metadata. And you can have something with metadata which is not editable.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- MetadataAwareBlockServiceInterface

### Deprecated
- EditableServiceInterface::getMetadata
```