### PR TITLE
Deprecate ContainerBlockService

### DIFF
--- a/src/Block/Service/ContainerBlockService.php
+++ b/src/Block/Service/ContainerBlockService.php
@@ -28,9 +28,11 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Render children pages.
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/block-bundle 4.x and will be removed in 5.0.
  */
 final class ContainerBlockService extends AbstractBlockService implements EditableBlockService
 {
@@ -45,20 +47,20 @@ final class ContainerBlockService extends AbstractBlockService implements Editab
             'keys' => [
                 ['code', TextType::class, [
                     'required' => false,
-                    'label' => 'form.label_code',
+                    'label' => 'form.label_code', // NEXT_MAJOR: Remove the translations.
                     'translation_domain' => 'SonataBlockBundle',
                 ]],
                 ['layout', TextareaType::class, [
-                    'label' => 'form.label_layout',
+                    'label' => 'form.label_layout', // NEXT_MAJOR: Remove the translations.
                     'translation_domain' => 'SonataBlockBundle',
                 ]],
                 ['class', TextType::class, [
                     'required' => false,
-                    'label' => 'form.label_class',
+                    'label' => 'form.label_class', // NEXT_MAJOR: Remove the translations.
                     'translation_domain' => 'SonataBlockBundle',
                 ]],
                 ['template', ContainerTemplateType::class, [
-                    'label' => 'form.label_template',
+                    'label' => 'form.label_template', // NEXT_MAJOR: Remove the translations.
                     'translation_domain' => 'SonataBlockBundle',
                 ]],
             ],
@@ -96,6 +98,7 @@ final class ContainerBlockService extends AbstractBlockService implements Editab
 
     public function getMetadata(): MetadataInterface
     {
+        // NEXT_MAJOR: Remove the related translations.
         return new Metadata('sonata.block.service.container', null, null, 'SonataBlockBundle', [
             'class' => 'fa fa-square-o',
         ]);

--- a/src/Resources/config/block.php
+++ b/src/Resources/config/block.php
@@ -23,6 +23,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // Use "service" function for creating references to services when dropping support for Symfony 4.4
     $services = $containerConfigurator->services();
 
+    // NEXT_MAJOR: Remove this service.
     $services->set('sonata.block.service.container', ContainerBlockService::class)
         ->tag('sonata.block')
         ->args([


### PR DESCRIPTION
## Subject

@jordisala1991 The containerBlockService is referencing `@SonataBlock/Block/block_container.html.twig` here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/src/Block/Service/ContainerBlockService.php#L89

Do you know what should I do about this template since it always referenced here:
https://github.com/sonata-project/SonataBlockBundle/blob/4.x/src/DependencyInjection/SonataBlockExtension.php#L40-L44
and
https://github.com/sonata-project/SonataBlockBundle/blob/4.x/src/DependencyInjection/SonataBlockExtension.php#L85-L90

Also, isn't it weird to have
- a container config https://github.com/sonata-project/SonataBlockBundle/blob/4.x/src/DependencyInjection/Configuration.php#L117-L142 should be deprecated/removed too,
- a containerTemplate type https://github.com/sonata-project/SonataBlockBundle/blob/4.x/src/Form/Type/ContainerTemplateType.php
- but no container blocks

I kinda forget the reason of the deprecation of this block. Does it make sens to have all this stuff container-related in BlockBundle even without a ContainerBlock (I dunno what's for) or should we fix the ContainerblockService ?

Closes #1109.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- ContainerBlockService
```
