### PR TITLE
BlockExceptionInterface should extends Throwable

### DIFF
--- a/src/Exception/BlockExceptionInterface.php
+++ b/src/Exception/BlockExceptionInterface.php
@@ -16,6 +16,6 @@ namespace Sonata\BlockBundle\Exception;
 /**
  * Interface to implement exception identified as block-specific exceptions.
  */
-interface BlockExceptionInterface
+interface BlockExceptionInterface extends \Throwable
 {
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

On 5.x because BC break

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- BlockExceptionInterface extends Throwable
```