### PR TITLE
Fix init of block settings

### DIFF
--- a/src/Block/BlockContextManager.php
+++ b/src/Block/BlockContextManager.php
@@ -134,6 +134,8 @@ final class BlockContextManager implements BlockContextManagerInterface
                 // merge user settings
                 $settings = array_merge($meta['settings'], $settings);
             }
+
+            $block->setSettings($settings);
         } else {
             $block = $meta;
         }

--- a/tests/Block/BlockContextManagerTest.php
+++ b/tests/Block/BlockContextManagerTest.php
@@ -21,6 +21,7 @@ use Sonata\BlockBundle\Block\BlockContextManager;
 use Sonata\BlockBundle\Block\BlockLoaderInterface;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Model\BlockInterface;
 
 final class BlockContextManagerTest extends TestCase
@@ -56,6 +57,46 @@ final class BlockContextManagerTest extends TestCase
             'template' => 'custom.html.twig',
             // NEXT_MAJOR: remove
             'ttl' => 0,
+        ], $blockContext->getSettings());
+    }
+
+    public function testGetWithBlockMeta(): void
+    {
+        $service = $this->createMock(AbstractBlockService::class);
+
+        $service->expects(static::once())->method('configureSettings');
+
+        $blockLoader = $this->createMock(BlockLoaderInterface::class);
+        $blockLoader->expects(static::once())->method('load')->willReturn($block = new Block());
+
+        $serviceManager = $this->createMock(BlockServiceManagerInterface::class);
+        $serviceManager->expects(static::once())->method('get')->willReturn($service);
+
+        $blockMeta = [
+            'type' => 'some_block_id',
+        ];
+
+        $manager = new BlockContextManager($blockLoader, $serviceManager);
+
+        $settings = ['template' => 'custom.html.twig'];
+
+        $blockContext = $manager->get($blockMeta, $settings);
+
+        static::assertInstanceOf(BlockContextInterface::class, $blockContext);
+
+        static::assertSame([
+            'template' => 'custom.html.twig',
+        ], $block->getSettings());
+
+        static::assertSame([
+            // NEXT_MAJOR: remove
+            'use_cache' => true,
+            // NEXT_MAJOR: remove
+            'extra_cache_keys' => [],
+            'attr' => [],
+            'template' => 'custom.html.twig',
+            // NEXT_MAJOR: remove
+            'ttl' => 86400,
         ], $blockContext->getSettings());
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is a bug fix for the usage without the page bundle.

```twig
    {{ sonata_block_render({ 'type': 'sonata.media.block.gallery' }, {
        // ...
        "galleryId": 2
    }) }}
```

When passing a block definition `$meta` array to this method, the `$settings` will be ignored for this block itself, they are only passed to the block context. This will result in a null value for different blocks (e.g. https://github.com/sonata-project/SonataMediaBundle/blob/9946d8ac3e0f21f1198050e5f7501766b058e53a/src/Block/GalleryBlockService.php#L169).


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix init of block settings
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
