### PR TITLE
Upgrade-4.0.md - fix links to 3.x

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -13,9 +13,9 @@ You need to register the new extensions in you AppKernel.
 
 All the deprecated code introduced on 3.x is removed on 4.0.
 
-Please read [3.x](https://github.com/sonata-project/SonataAdminBundle/tree/3.x) upgrade guides for more information.
+Please read [3.x](https://github.com/sonata-project/SonataBlockBundle/blob/3.x/UPGRADE-3.x.md) upgrade guides for more information.
 
-See also the [diff code](https://github.com/sonata-project/SonataAdminBundle/compare/3.x...4.0.0).
+See also the [diff code](https://github.com/sonata-project/SonataBlockBundle/compare/3.x...4.0.0).
 
 ## Block id
 


### PR DESCRIPTION
Links to 3.x and diff code lead to AdminBundle instead of BlockBundle.