### PR TITLE
fix: form validations are by passed when an Exception is thrown

### DIFF
--- a/src/Block/BlockServiceManager.php
+++ b/src/Block/BlockServiceManager.php
@@ -149,8 +149,10 @@ final class BlockServiceManager implements BlockServiceManagerInterface
             }
 
             $this->inValidate = false;
-        } catch (\Exception) {
+        } catch (\Exception $exception) {
             $this->inValidate = false;
+
+            throw $exception;
         }
     }
 


### PR DESCRIPTION
## Subject

fix: form validations are by passed when an Exception is thrown

I am targeting this branch, because it is a fix. 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1217

## Changelog
```markdown
### Fixed
- fix: form validations are by passed when an Exception is thrown
```

## To do

- [ ] Update the tests;


