### PR TITLE
fixes BlockServiceTestCase

### DIFF
--- a/docs/reference/testing.rst
+++ b/docs/reference/testing.rst
@@ -32,9 +32,9 @@ Given the following block service::
 
 You can write unit tests for block services with the following code::
 
-    use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+    use Sonata\BlockBundle\Test\BlockServiceTestCase;
 
-    class CustomBlockServiceTest extends AbstractBlockServiceTestCase
+    class CustomBlockServiceTest extends BlockServiceTestCase
     {
         public function testDefaultSettings(): void
         {
@@ -46,18 +46,5 @@ You can write unit tests for block services with the following code::
                 'attr' => [],
                 'template' => false,
             ], $blockContext);
-        }
-
-        public function testExecute(): void
-        {
-            $blockService = new CustomBlockService('foo', $this->twig);
-            $blockContext = $this->getBlockContext($blockService);
-
-            $blockService->execute($blockContext);
-
-            $this->assertSame($blockContext, $this->templating->parameters['context']);
-            $this->assertInternalType('array', $this->templating->parameters['settings']);
-            $this->assertInstanceOf('Sonata\BlockBundle\Model\BlockInterface', $this->templating->parameters['block']);
-            $this->assertSame('bar', $this->templating->parameters['foo']);
         }
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Looks like the docs are outdated, as there is no such `AbstractBlockServiceTestCase`.

I weren't able to `execute()` my block either, because `Twig` get's mocked. Not sure what to test though. That's why I suggest removing these lines.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

~~Closes #{put_issue_number_here}.~~

