### PR TITLE
Fix symfony 7.3 deprecation in RssBlockService

### DIFF
--- a/src/Block/Service/RssBlockService.php
+++ b/src/Block/Service/RssBlockService.php
@@ -94,7 +94,7 @@ final class RssBlockService extends AbstractBlockService implements EditableBloc
             ->with('settings[title]')
                 ->addConstraint(new NotNull())
                 ->addConstraint(new NotBlank())
-                ->addConstraint(new Length(['max' => 50]))
+                ->addConstraint(new Length(max: 50))
             ->end();
     }
 

--- a/src/Block/Service/RssBlockService.php
+++ b/src/Block/Service/RssBlockService.php
@@ -56,6 +56,7 @@ final class RssBlockService extends AbstractBlockService implements EditableBloc
             'keys' => [
                 ['url', UrlType::class, [
                     'required' => false,
+                    'default_protocol' => 'https',
                     'label' => 'form.label_url',
                     'translation_domain' => 'SonataBlockBundle',
                 ]],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Fix symfony 7.3 deprecation in RssBlockService

<!-- Describe your Pull Request content here -->
Since symfony/validator 7.3: Passing an array of options to configure the "Symfony\Component\Validator\Constraints\Length" constraint is deprecated, use named arguments instead.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Changed
- Changed passing `array` to `named` argument for `Length` validation constraint in `src/Block/Service/RssBlockService.php`

### Added
- Added `default_protocol` equals `true` for UrlType` at `src/Block/Service/RssBlockService.php`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

Related with: https://github.com/sonata-project/SonataPageBundle/issues/1837
