### PR TITLE
doctrine/collections: add support for v3 and drop v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "homepage": "https://docs.sonata-project.org/projects/SonataBlockBundle",
     "require": {
         "php": "^8.2",
-        "doctrine/collections": "^1.8 || ^2.0",
+        "doctrine/collections": "^2.0 || ^3.0",
         "doctrine/common": "^3.0",
         "psr/container": "^1.0 || ^2.0",
         "psr/log": "^2.0 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataBlockBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
- support for `doctrine/collections` 3

### Removed
- support for `doctrine/collections` < 2
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

v2 was released in 2022... I don't see a reason to keep supporting v1?